### PR TITLE
feat: cudu cli

### DIFF
--- a/.github/workflows/ci-python-project.yml
+++ b/.github/workflows/ci-python-project.yml
@@ -3,6 +3,8 @@ name: Continuous Integration for "issue-solver" Python project
 on:
   push:
     branches: [ "main" ]
+    tags:
+      - 'v*'    # e.g. v1.0.0, v2.3.4
   pull_request:
     branches: [ "main" ]
 
@@ -35,3 +37,31 @@ jobs:
 
       - name: Run tests
         run: just test
+  publish:
+    name: Build and Publish to PyPI
+    needs: build-and-test
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v')  # only run if it's a tag matching 'v*'
+    defaults:
+      run:
+        working-directory: ./issue-solver
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: extractions/setup-just@v2
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+
+      - name: Set up Python
+        run: uv python install
+
+      - name: Install dependencies
+        run: uv sync --all-extras --dev
+
+      - name: Build distribution
+        run: uv build
+
+      - name: Publish to PyPI
+        run: uv publish --token ${{ secrets.PYPI_TOKEN }}

--- a/issue-solver/justfile
+++ b/issue-solver/justfile
@@ -29,4 +29,8 @@ api-start:
 
 # ▶️ Run standalone issue solver
 run:
-    sudo uv run issue-solver
+    uv run issue-solver help
+
+# 🧩 Run cudu cli to solve issue
+solve:
+    sudo uv run issue-solver solve

--- a/issue-solver/justfile
+++ b/issue-solver/justfile
@@ -29,8 +29,8 @@ api-start:
 
 # ▶️ Run standalone issue solver
 run:
-    uv run issue-solver help
+    uv run cudu help
 
 # 🧩 Run cudu cli to solve issue
 solve:
-    sudo uv run issue-solver solve
+    sudo uv run cudu solve

--- a/issue-solver/pyproject.toml
+++ b/issue-solver/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "issue-solver"
-version = "0.1.0"
+version = "0.1.1-rc.1"
 description = "A tool to specify, solve issues and review code in a repository using an autonomous agents."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/issue-solver/pyproject.toml
+++ b/issue-solver/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "issue-solver"
 version = "0.1.0"
-description = "A tool to solve issues in a repository using an autonomous agents."
+description = "A tool to specify, solve issues and review code in a repository using an autonomous agents."
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
@@ -16,7 +16,7 @@ dependencies = [
 ]
 
 [project.scripts]
-issue-solver = "issue_solver.standalone.__main__:run_main"
+cudu = "issue_solver.standalone.__main__:run_main"
 
 [build-system]
 requires = ["hatchling"]

--- a/issue-solver/src/issue_solver/app_settings.py
+++ b/issue-solver/src/issue_solver/app_settings.py
@@ -35,7 +35,7 @@ class IssueSettings:
     ref: IssueReference
 
 
-class AppSettings(BaseSettings):
+class SolveCommandSettings(BaseSettings):
     model_config = SettingsConfigDict(
         env_nested_delimiter="__",
         env_file=".env",

--- a/issue-solver/src/issue_solver/standalone/CuduCli.py
+++ b/issue-solver/src/issue_solver/standalone/CuduCli.py
@@ -1,0 +1,67 @@
+import sys
+
+from pydantic import ValidationError
+from pydantic_settings import CliApp, SettingsError
+
+from issue_solver.standalone.ReviewCommand import ReviewSettings
+from issue_solver.standalone.SolveCommand import SolveCommand
+
+
+class CuduCLI:
+    @classmethod
+    def run(
+        cls,
+    ) -> None:
+        if len(sys.argv) < 2:
+            show_usage()
+            sys.exit(1)
+
+        subcmd = sys.argv[1]
+        sub_args = sys.argv[2:]
+        try:
+            if subcmd == "solve":
+                CliApp.run(
+                    model_cls=SolveCommand,
+                    cli_args=sub_args,  # le reste des arguments
+                    cli_cmd_method_name="cli_cmd",
+                )
+            elif subcmd == "review":
+                CliApp.run(
+                    model_cls=ReviewSettings,
+                    cli_args=sub_args,
+                    cli_cmd_method_name="cli_cmd",
+                )
+            elif subcmd in ("help", "-h", "--help"):
+                show_usage()
+                sys.exit(0)
+            else:
+                print(f"Unknown subcommand: {subcmd}")
+                show_usage()
+                sys.exit(1)
+        except ValidationError as e:
+            print("[ERROR] Invalid arguments or fields:\n")
+            errors = e.errors()
+            for err in errors:
+                print(f" - {err['loc']}: {err['msg']} | input: {err['input']}")
+            sys.exit(2)
+
+        except SettingsError as e:
+            print("[ERROR] Bad configuration or CLI usage:\n")
+            print(e)
+            sys.exit(2)
+
+
+def show_usage() -> None:
+    """Show general help for the `cudu` CLI."""
+    print("""
+    Usage: cudu [subcommand] [options...]
+    Subcommands:
+      solve    🧩 solve an issue
+      review   👀 review a pull request or issue
+      help     🛟 show this message
+    
+    Examples:
+      cudu solve --repo-path=. --agent=swe-crafter
+      cudu review --repo-path=.
+      cudu solve --help       # show help about the 'solve' subcommand
+    """)

--- a/issue-solver/src/issue_solver/standalone/ReviewCommand.py
+++ b/issue-solver/src/issue_solver/standalone/ReviewCommand.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+
+from pydantic import Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class ReviewSettings(BaseSettings):
+    model_config = SettingsConfigDict(
+        env_file=".env",
+        env_nested_delimiter="__",
+        extra="ignore",
+    )
+
+    repo_path: Path = Field(default=Path("."))
+
+    def cli_cmd(self) -> None:
+        print(f"[review] 👀 Reviewing in repo={self.repo_path}")

--- a/issue-solver/src/issue_solver/standalone/SolveCommand.py
+++ b/issue-solver/src/issue_solver/standalone/SolveCommand.py
@@ -1,0 +1,49 @@
+import asyncio
+from typing import assert_never
+
+from issue_solver.agents.issue_resolving_agent import ResolveIssueCommand
+from issue_solver.agents.supported_agents import SupportedAgent
+from issue_solver.app_settings import SolveCommandSettings, IssueSettings
+from issue_solver.git_operations.git_helper import GitHelper
+from issue_solver.issues.issue import IssueInfo
+from issue_solver.issues.trackers.supported_issue_trackers import SupportedIssueTracker
+
+
+class SolveCommand(SolveCommandSettings):
+    def cli_cmd(self) -> None:
+        print(
+            f"[solve] 🧩 Solving issue='{self.issue}' with agent={self.agent} in repo={self.repo_path}"
+        )
+        asyncio.run(self.run_solve())
+
+    async def run_solve(self) -> None:
+        return await main(self)
+
+
+async def main(settings: SolveCommandSettings) -> None:
+    issue_info = describe(settings.issue)
+    agent = SupportedAgent.get(settings.agent, settings.model_settings)
+    await agent.resolve_issue(
+        ResolveIssueCommand(
+            model=settings.versioned_ai_model,
+            issue=issue_info,
+            repo_path=settings.repo_path,
+        )
+    )
+    GitHelper.of(settings.git, settings.model_settings).commit_and_push(
+        issue_info, settings.repo_path
+    )
+
+
+def describe(issue: IssueInfo | IssueSettings) -> IssueInfo:
+    match issue:
+        case IssueSettings():
+            issue_tracker = SupportedIssueTracker.get(issue.tracker)
+            issue_info = issue_tracker.describe_issue(issue.ref)
+        case IssueInfo():
+            issue_info = issue
+        case _:
+            assert_never(issue)
+    if issue_info is None:
+        raise ValueError("Issue info could not be found. for issue: {issue}")
+    return issue_info

--- a/issue-solver/src/issue_solver/standalone/__main__.py
+++ b/issue-solver/src/issue_solver/standalone/__main__.py
@@ -1,46 +1,8 @@
-import asyncio
-from typing import assert_never
-
-from issue_solver.agents.issue_resolving_agent import ResolveIssueCommand
-from issue_solver.agents.supported_agents import SupportedAgent
-from issue_solver.app_settings import AppSettings, IssueSettings
-from issue_solver.git_operations.git_helper import GitHelper
-from issue_solver.issues.issue import IssueInfo
-from issue_solver.issues.trackers.supported_issue_trackers import SupportedIssueTracker
-
-
-async def main() -> None:
-    settings = AppSettings()
-    issue_info = describe(settings.issue)
-    agent = SupportedAgent.get(settings.agent, settings.model_settings)
-    await agent.resolve_issue(
-        ResolveIssueCommand(
-            model=settings.versioned_ai_model,
-            issue=issue_info,
-            repo_path=settings.repo_path,
-        )
-    )
-    GitHelper.of(settings.git, settings.model_settings).commit_and_push(
-        issue_info, settings.repo_path
-    )
-
-
-def describe(issue: IssueInfo | IssueSettings) -> IssueInfo:
-    match issue:
-        case IssueSettings():
-            issue_tracker = SupportedIssueTracker.get(issue.tracker)
-            issue_info = issue_tracker.describe_issue(issue.ref)
-        case IssueInfo():
-            issue_info = issue
-        case _:
-            assert_never(issue)
-    if issue_info is None:
-        raise ValueError("Issue info could not be found. for issue: {issue}")
-    return issue_info
+from issue_solver.standalone.CuduCli import CuduCLI
 
 
 def run_main() -> None:
-    asyncio.run(main())
+    CuduCLI.run()
 
 
 if __name__ == "__main__":

--- a/issue-solver/tests/test_app_settings.py
+++ b/issue-solver/tests/test_app_settings.py
@@ -6,7 +6,7 @@ from pydantic import ValidationError
 from pydantic_core import Url
 
 from issue_solver.agents.supported_agents import SupportedAgent
-from issue_solver.app_settings import IssueSettings, AppSettings
+from issue_solver.app_settings import IssueSettings, SolveCommandSettings
 from issue_solver.issues.issue import IssueInternalId, IssueInfo
 from issue_solver.issues.trackers.azure_devops_issue_tracker import (
     AzureDevOpsIssueTracker,
@@ -34,7 +34,7 @@ from issue_solver.models.supported_models import (
 @pytest.fixture
 def clean_env() -> None:
     # to test in isolation and avoid side effects due to local env vars
-    AppSettings.model_config["env_file"] = ""
+    SolveCommandSettings.model_config["env_file"] = ""
     os.environ.clear()
 
 
@@ -47,7 +47,7 @@ def test_minimal_valid_app_settings_with_default_values(clean_env: None) -> None
     os.environ["OPENAI_API_KEY"] = "openai-test-key"
 
     # When
-    app_settings = AppSettings()
+    app_settings = SolveCommandSettings()
 
     # Then
     assert app_settings.issue == IssueInfo(description=issue_description)
@@ -93,7 +93,7 @@ def test_full_valid_app_settings_with_gitlab_swe_crafter_and_anthropic(
     os.environ["GIT__USER_NAME"] = git_user_name
 
     # When
-    app_settings = AppSettings()
+    app_settings = SolveCommandSettings()
 
     # Then
     selected_issue_tracker = app_settings.selected_issue_tracker
@@ -124,7 +124,7 @@ def test_openai_model_with_required_fields(clean_env: None) -> None:
     os.environ["AI_MODEL"] = SupportedOpenAIModel.GPT4O
 
     # When
-    app_settings = AppSettings()
+    app_settings = SolveCommandSettings()
     model_settings = app_settings.model_settings
 
     # Then
@@ -141,7 +141,7 @@ def test_deepseek_model_with_required_fields(clean_env: None) -> None:
     os.environ["DEEPSEEK_API_KEY"] = "deepseek-key"
 
     # When
-    app_settings = AppSettings()
+    app_settings = SolveCommandSettings()
     model_settings = app_settings.model_settings
 
     # Then
@@ -160,7 +160,7 @@ def test_anthropic_model_with_required_fields(clean_env: None) -> None:
     os.environ["ANTHROPIC_BASE_URL"] = "https://api.anthropic.example.org"
 
     # When
-    app_settings = AppSettings()
+    app_settings = SolveCommandSettings()
     model_settings = app_settings.model_settings
 
     # Then
@@ -178,7 +178,7 @@ def test_qwen_model_with_required_fields(clean_env: None) -> None:
     os.environ["QWEN_API_KEY"] = "qwen-test-key"
 
     # When
-    app_settings = AppSettings()
+    app_settings = SolveCommandSettings()
     model_settings = app_settings.model_settings
 
     # Then
@@ -196,7 +196,7 @@ def test_issue_settings_gitlab_tracker(clean_env: None) -> None:
     os.environ["ISSUE__REF__IID"] = "888"
 
     # When
-    app_settings = AppSettings()
+    app_settings = SolveCommandSettings()
 
     # Then
     assert isinstance(app_settings.issue, IssueSettings)
@@ -215,7 +215,7 @@ def test_issue_info_no_tracker(clean_env: None) -> None:
     os.environ["ISSUE__DESCRIPTION"] = "Some plain description"
 
     # When
-    app_settings = AppSettings()
+    app_settings = SolveCommandSettings()
 
     # Then
     assert isinstance(app_settings.issue, IssueInfo)
@@ -230,7 +230,7 @@ def test_custom_repo_path(clean_env: None) -> None:
     os.environ["REPO_PATH"] = "/custom/repo/path"
 
     # When
-    app_settings = AppSettings()
+    app_settings = SolveCommandSettings()
 
     # Then
     assert app_settings.repo_path == Path("/custom/repo/path")
@@ -244,7 +244,7 @@ def test_invalid_model_raises_validation_error(clean_env: None) -> None:
 
     # When / Then
     with pytest.raises(ValidationError):
-        _ = AppSettings()
+        _ = SolveCommandSettings()
 
 
 def test_incomplete_tracker_info_raises_error(clean_env: None) -> None:
@@ -255,7 +255,7 @@ def test_incomplete_tracker_info_raises_error(clean_env: None) -> None:
 
     # When / Then
     with pytest.raises(ValidationError):
-        _ = AppSettings()
+        _ = SolveCommandSettings()
 
 
 def test_selected_model_with_settings(clean_env: None) -> None:
@@ -268,7 +268,7 @@ def test_selected_model_with_settings(clean_env: None) -> None:
     os.environ["ANTHROPIC_BASE_URL"] = "https://api.anthropic.example.org"
 
     # When
-    app_settings = AppSettings()
+    app_settings = SolveCommandSettings()
     model_with_settings = app_settings.selected_model_with_settings
 
     # Then
@@ -291,7 +291,7 @@ def test_github_tracker_is_interpreted_correctly(clean_env: None) -> None:
     os.environ["GIT__ACCESS_TOKEN"] = "some-git-access-token"
 
     # When
-    app_settings = AppSettings()
+    app_settings = SolveCommandSettings()
 
     # Then
     assert isinstance(app_settings.issue, IssueSettings)
@@ -312,7 +312,7 @@ def test_jira_tracker_is_interpreted_correctly(clean_env: None) -> None:
     os.environ["GIT__ACCESS_TOKEN"] = "some-git-access-token"
 
     # When
-    app_settings = AppSettings()
+    app_settings = SolveCommandSettings()
 
     # Then
     assert isinstance(app_settings.issue, IssueSettings)
@@ -331,7 +331,7 @@ def test_trello_tracker_is_interpreted_correctly(clean_env: None) -> None:
     os.environ["GIT__ACCESS_TOKEN"] = "some-git-access-token"
 
     # When
-    app_settings = AppSettings()
+    app_settings = SolveCommandSettings()
 
     # Then
     assert isinstance(app_settings.issue, IssueSettings)
@@ -348,7 +348,7 @@ def test_azure_devops_tracker_is_interpreted_correctly(clean_env: None) -> None:
     os.environ["GIT__ACCESS_TOKEN"] = "some-git-access-token"
 
     # When
-    app_settings = AppSettings()
+    app_settings = SolveCommandSettings()
 
     # Then
     assert isinstance(app_settings.issue, IssueSettings)
@@ -366,7 +366,7 @@ def test_http_based_tracker_is_interpreted_correctly(clean_env: None) -> None:
     os.environ["GIT__ACCESS_TOKEN"] = "some-git-access-token"
 
     # When
-    app_settings = AppSettings()
+    app_settings = SolveCommandSettings()
 
     # Then
     assert isinstance(app_settings.issue, IssueSettings)
@@ -385,7 +385,7 @@ def test_notion_tracker_is_interpreted_correctly(clean_env: None) -> None:
     os.environ["GIT__ACCESS_TOKEN"] = "some-git-access-token"
 
     # When
-    app_settings = AppSettings()
+    app_settings = SolveCommandSettings()
 
     # Then
     assert isinstance(app_settings.issue, IssueSettings)


### PR DESCRIPTION
This PR refactors the existing script into a CLI using [Pydantic v2’s `CliApp`](https://docs.pydantic.dev/latest/concepts/pydantic_settings/#creating-cli-applications), introduces a new custom entry point (`cudu`), and adds a publishing workflow to automate package releases on PyPI.

Key changes:
- **CLI Transformation**: Replaces the original script with a CLI that supports subcommands (`solve` and `review`), making it more modular and easier to extend.  review subcommand is not implemented yet (currently, it is just a placeholder)
- **Refactoring & Renaming**: Renames `AppSettings` to `SolveCommandSettings` and updates references across the codebase. The script’s entry point is now `cudu` instead of `issue-solver`.  
- **PyPI Packaging & Workflow**: Adds a new GitHub Actions job to build and publish the package to PyPI when a `v*` tag is pushed, streamlining the release process.  