### PR TITLE
feat(git): inject access token into repository clone URL for secure access

### DIFF
--- a/issue-solver/src/issue_solver/git_operations/git_helper.py
+++ b/issue-solver/src/issue_solver/git_operations/git_helper.py
@@ -101,7 +101,7 @@ class GitHelper:
         Clone the repository to the current working directory.
         """
         repo = Repo.clone_from(
-            self.settings.repository_url,
+            self._inject_access_token(self.settings.repository_url),
             to_path=to_path,
             env={"GIT_TERMINAL_PROMPT": "0"},
             depth=1,


### PR DESCRIPTION
This pull request includes a significant change to the `clone_repository` method in the `git_helper.py` file to enhance security by injecting an access token into the repository URL.

Security enhancement:

* [`issue-solver/src/issue_solver/git_operations/git_helper.py`](diffhunk://#diff-0736522f455c96e4a01481badeff1b3fb7bdb951f10f9ef4276958fcf2df608dL104-R104): Modified the `clone_repository` method to inject an access token into the repository URL for the `Repo.clone_from` function.…ccess 🔑✨