### PR TITLE
feat(api): configure custom domain for API Gateway and add related outputs ✨

### DIFF
--- a/operations/01-provision/dns-and-certificates.tf
+++ b/operations/01-provision/dns-and-certificates.tf
@@ -26,3 +26,19 @@ resource "null_resource" "dns_validation_instructions" {
     EOT
   }
 }
+
+# Wait for certificate validation
+# Note: This makes Terraform wait for the certificate to be validated
+# You'll need to manually create the DNS records in Namecheap
+resource "aws_acm_certificate_validation" "umans_ai" {
+  certificate_arn = aws_acm_certificate.umans_ai.arn
+  
+  # We're not providing validation_record_fqdns since we're not creating the records ourselves
+  # This will make Terraform wait for the certificate to be validated by AWS
+  # before proceeding with resources that depend on the certificate
+
+  # Set a longer timeout as DNS propagation and validation can take time
+  timeouts {
+    create = "60m"
+  }
+}

--- a/operations/01-provision/dns-and-certificates.tf
+++ b/operations/01-provision/dns-and-certificates.tf
@@ -1,0 +1,39 @@
+# Zone hébergée Route53 pour umans.ai
+resource "aws_route53_zone" "umans_ai" {
+  name = "umans.ai"
+}
+
+# Certificat ACM pour *.umans.ai et umans.ai
+resource "aws_acm_certificate" "umans_ai" {
+  domain_name               = "umans.ai"
+  subject_alternative_names = ["*.umans.ai"]
+  validation_method         = "DNS"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+# Enregistrements DNS pour la validation du certificat
+resource "aws_route53_record" "cert_validation" {
+  for_each = {
+    for dvo in aws_acm_certificate.umans_ai.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
+  }
+
+  allow_overwrite = true
+  name            = each.value.name
+  records         = [each.value.record]
+  ttl             = 60
+  type            = each.value.type
+  zone_id         = aws_route53_zone.umans_ai.zone_id
+}
+
+# Validation du certificat
+resource "aws_acm_certificate_validation" "umans_ai" {
+  certificate_arn         = aws_acm_certificate.umans_ai.arn
+  validation_record_fqdns = [for record in aws_route53_record.cert_validation : record.fqdn]
+} 

--- a/operations/01-provision/dns-and-certificates.tf
+++ b/operations/01-provision/dns-and-certificates.tf
@@ -1,9 +1,4 @@
-# Zone hébergée Route53 pour umans.ai
-resource "aws_route53_zone" "umans_ai" {
-  name = "umans.ai"
-}
-
-# Certificat ACM pour *.umans.ai et umans.ai
+# ACM Certificate for *.umans.ai and umans.ai
 resource "aws_acm_certificate" "umans_ai" {
   domain_name               = "umans.ai"
   subject_alternative_names = ["*.umans.ai"]
@@ -14,26 +9,20 @@ resource "aws_acm_certificate" "umans_ai" {
   }
 }
 
-# Enregistrements DNS pour la validation du certificat
-resource "aws_route53_record" "cert_validation" {
-  for_each = {
-    for dvo in aws_acm_certificate.umans_ai.domain_validation_options : dvo.domain_name => {
-      name   = dvo.resource_record_name
-      record = dvo.resource_record_value
-      type   = dvo.resource_record_type
-    }
+# Display DNS validation instructions
+resource "null_resource" "dns_validation_instructions" {
+  provisioner "local-exec" {
+    command = <<-EOT
+      echo "==================================================================="
+      echo "IMPORTANT: Create the following DNS records in Namecheap:"
+      %{for dvo in aws_acm_certificate.umans_ai.domain_validation_options~}
+      echo "Type: ${dvo.resource_record_type}"
+      echo "Host: ${replace(dvo.resource_record_name, ".umans.ai.", "")}"
+      echo "Value: ${dvo.resource_record_value}"
+      echo "TTL: 60"
+      echo "-------------------------------------------------------------------"
+      %{endfor~}
+      echo "==================================================================="
+    EOT
   }
-
-  allow_overwrite = true
-  name            = each.value.name
-  records         = [each.value.record]
-  ttl             = 60
-  type            = each.value.type
-  zone_id         = aws_route53_zone.umans_ai.zone_id
 }
-
-# Validation du certificat
-resource "aws_acm_certificate_validation" "umans_ai" {
-  certificate_arn         = aws_acm_certificate.umans_ai.arn
-  validation_record_fqdns = [for record in aws_route53_record.cert_validation : record.fqdn]
-} 

--- a/operations/01-provision/output.tf
+++ b/operations/01-provision/output.tf
@@ -44,7 +44,14 @@ output "certificate_arn" {
   description = "ARN of the SSL certificate for the *.umans.ai domain"
 }
 
-output "hosted_zone_id" {
-  value = aws_route53_zone.umans_ai.zone_id
-  description = "ID of the Route53 hosted zone for umans.ai"
+# DNS validation information to be configured in Namecheap
+output "certificate_validation_options" {
+  value = [
+    for dvo in aws_acm_certificate.umans_ai.domain_validation_options : {
+      name   = replace(dvo.resource_record_name, ".umans.ai.", "")
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
+  ]
+  description = "DNS records to create in Namecheap to validate the SSL certificate"
 }

--- a/operations/01-provision/output.tf
+++ b/operations/01-provision/output.tf
@@ -44,6 +44,12 @@ output "certificate_arn" {
   description = "ARN of the SSL certificate for the *.umans.ai domain"
 }
 
+output "certificate_validation_status" {
+  value       = "Certificate validation completed. You can now deploy the API domain."
+  description = "Indicates that the certificate has been validated"
+  depends_on  = [aws_acm_certificate_validation.umans_ai]
+}
+
 # DNS validation information to be configured in Namecheap
 output "certificate_validation_options" {
   value = [

--- a/operations/01-provision/output.tf
+++ b/operations/01-provision/output.tf
@@ -38,3 +38,13 @@ output "blob_secret_access_key" {
   value = aws_iam_access_key.conversational_ui_blob_access_key.secret
   sensitive = true
 }
+
+output "certificate_arn" {
+  value = aws_acm_certificate.umans_ai.arn
+  description = "ARN of the SSL certificate for the *.umans.ai domain"
+}
+
+output "hosted_zone_id" {
+  value = aws_route53_zone.umans_ai.zone_id
+  description = "ID of the Route53 hosted zone for umans.ai"
+}

--- a/operations/02-deploy/conversational-ui.tf
+++ b/operations/02-deploy/conversational-ui.tf
@@ -115,7 +115,7 @@ resource "vercel_project_environment_variables" "env_vars" {
     },
     {
       key    = "CUDU_ENDPOINT"
-      value  = "https://api.${local.domain_prefix}umans.ai"
+      value  = aws_apigatewayv2_stage.cudu_api.invoke_url
       target = [local.vercel_deployment_target]
     }
   ]

--- a/operations/02-deploy/conversational-ui.tf
+++ b/operations/02-deploy/conversational-ui.tf
@@ -19,7 +19,7 @@ resource "vercel_project" "conversational_ui" {
 
 resource "vercel_project_domain" "umans_ai" {
   project_id = vercel_project.conversational_ui.id
-  domain     = "${local.domain_prefix}umans.ai"
+  domain     = local.environment_name == "production" ? "umans.ai" : "pr-${local.environment_name}.umans.ai"
 }
 
 resource "vercel_project_domain" "app_umans_ai" {

--- a/operations/02-deploy/conversational-ui.tf
+++ b/operations/02-deploy/conversational-ui.tf
@@ -115,7 +115,7 @@ resource "vercel_project_environment_variables" "env_vars" {
     },
     {
       key    = "CUDU_ENDPOINT"
-      value  = aws_apigatewayv2_stage.cudu_api.invoke_url
+      value  = local.api_url
       target = [local.vercel_deployment_target]
     }
   ]

--- a/operations/02-deploy/conversational-ui.tf
+++ b/operations/02-deploy/conversational-ui.tf
@@ -115,7 +115,7 @@ resource "vercel_project_environment_variables" "env_vars" {
     },
     {
       key    = "CUDU_ENDPOINT"
-      value  = aws_apigatewayv2_api.cudu_api.api_endpoint
+      value  = "https://api.${local.domain_prefix}umans.ai"
       target = [local.vercel_deployment_target]
     }
   ]

--- a/operations/02-deploy/conversational-ui.tf
+++ b/operations/02-deploy/conversational-ui.tf
@@ -24,7 +24,7 @@ resource "vercel_project_domain" "umans_ai" {
 
 resource "vercel_project_domain" "app_umans_ai" {
   project_id = vercel_project.conversational_ui.id
-  domain     = "app.${local.domain_prefix}umans.ai"
+  domain     = local.ui_domain
 }
 
 resource "vercel_project_environment_variables" "env_vars" {

--- a/operations/02-deploy/conversational-ui.tf
+++ b/operations/02-deploy/conversational-ui.tf
@@ -19,7 +19,7 @@ resource "vercel_project" "conversational_ui" {
 
 resource "vercel_project_domain" "umans_ai" {
   project_id = vercel_project.conversational_ui.id
-  domain     = local.environment_name == "production" ? "umans.ai" : "pr-${local.environment_name}.umans.ai"
+  domain     = "${local.environment_name_suffix == "" ? "" : terraform.workspace}umans.ai"
 }
 
 resource "vercel_project_domain" "app_umans_ai" {

--- a/operations/02-deploy/main.tf
+++ b/operations/02-deploy/main.tf
@@ -20,10 +20,15 @@ locals {
   deployment_target              = terraform.workspace == "production" ? "production" : "preview"
   vercel_deployment_target       = "production"
   environment_name_suffix        = terraform.workspace == "production" ? "" : "-${local.environment_name}"
-  domain_prefix                  = terraform.workspace == "production" ? "" : "${local.environment_name}."
   conversational_ui_project_name = "conversational-ui${local.environment_name_suffix}"
-  auth_url                       = "https://app.${local.domain_prefix}umans.ai"
-  api_url                        = "https://api.${local.domain_prefix}umans.ai"
+  
+  # Modification des domaines pour éviter les sous-domaines imbriqués
+  domain_prefix                  = terraform.workspace == "production" ? "" : "${local.environment_name}-"
+  ui_domain                      = "app${local.domain_prefix}umans.ai"
+  api_domain                     = "api${local.domain_prefix}umans.ai"
+  
+  auth_url                       = "https://${local.ui_domain}"
+  api_url                        = "https://${local.api_domain}"
   
   # Use certificate ARN from the provision layer
   certificate_arn = data.terraform_remote_state.provision.outputs.certificate_arn

--- a/operations/02-deploy/main.tf
+++ b/operations/02-deploy/main.tf
@@ -23,4 +23,15 @@ locals {
   domain_prefix                 = terraform.workspace == "production" ? "" : "${local.environment_name}."
   conversational_ui_project_name = "conversational-ui${local.environment_name_suffix}"
   auth_url                       = "https://app.${local.domain_prefix}umans.ai"
+  
+  # Verify that certificate validation has been completed
+  # This will cause Terraform to fail if the certificate is not validated
+  certificate_validation_check = data.terraform_remote_state.provision.outputs.certificate_validation_status == "Certificate validation completed. You can now deploy the API domain." ? true : tobool("Certificate not validated yet. Please ensure DNS records are created and wait for validation to complete.")
+}
+
+# Explicitly query the certificate to verify it's validated
+data "aws_acm_certificate" "umans_ai" {
+  domain      = "umans.ai"
+  statuses    = ["ISSUED"]
+  most_recent = true
 }

--- a/operations/02-deploy/main.tf
+++ b/operations/02-deploy/main.tf
@@ -16,22 +16,18 @@ data "terraform_remote_state" "provision" {
 data "aws_caller_identity" "current" {}
 
 locals {
-  environment_name               = terraform.workspace
-  deployment_target              = terraform.workspace == "production" ? "production" : "preview"
-  vercel_deployment_target       = "production"
-  environment_name_suffix        = terraform.workspace == "production" ? "" : "-${local.environment_name}"
+  is_production                = terraform.workspace == "production"
+  pr_id                        = local.is_production ? "" : "pr-${terraform.workspace}-"
+  api_domain                   = local.is_production ? "api.umans.ai" : "${local.pr_id}api.umans.ai"
+  ui_domain                    = local.is_production ? "app.umans.ai" : "${local.pr_id}app.umans.ai"
+  environment_name             = terraform.workspace
+  deployment_target            = local.is_production ? "production" : "preview"
+  vercel_deployment_target     = "production"
+  environment_name_suffix      = local.is_production ? "" : "-${local.environment_name}"
   conversational_ui_project_name = "conversational-ui${local.environment_name_suffix}"
-  
-  # Modification des domaines pour éviter les sous-domaines imbriqués
-  domain_prefix                  = terraform.workspace == "production" ? "" : "${local.environment_name}-"
-  ui_domain                      = "app${local.domain_prefix}umans.ai"
-  api_domain                     = "api${local.domain_prefix}umans.ai"
-  
-  auth_url                       = "https://${local.ui_domain}"
-  api_url                        = "https://${local.api_domain}"
-  
-  # Use certificate ARN from the provision layer
-  certificate_arn = data.terraform_remote_state.provision.outputs.certificate_arn
+  auth_url                     = "https://${local.ui_domain}"
+  api_url                      = "https://${local.api_domain}"
+  certificate_arn              = data.terraform_remote_state.provision.outputs.certificate_arn
 }
 
 # Commenting out the certificate lookup as we'll use the hardcoded ARN

--- a/operations/02-deploy/main.tf
+++ b/operations/02-deploy/main.tf
@@ -31,7 +31,8 @@ locals {
 
 # Explicitly query the certificate to verify it's validated
 data "aws_acm_certificate" "umans_ai" {
-  domain      = "umans.ai"
+  domain      = "*.umans.ai"  # Explicitly query for the wildcard cert
   statuses    = ["ISSUED"]
+  types       = ["AMAZON_ISSUED"]
   most_recent = true
 }

--- a/operations/02-deploy/main.tf
+++ b/operations/02-deploy/main.tf
@@ -16,18 +16,17 @@ data "terraform_remote_state" "provision" {
 data "aws_caller_identity" "current" {}
 
 locals {
-  is_production                = terraform.workspace == "production"
-  pr_id                        = local.is_production ? "" : "pr-${terraform.workspace}-"
-  api_domain                   = local.is_production ? "api.umans.ai" : "${local.pr_id}api.umans.ai"
-  ui_domain                    = local.is_production ? "app.umans.ai" : "${local.pr_id}app.umans.ai"
-  environment_name             = terraform.workspace
-  deployment_target            = local.is_production ? "production" : "preview"
-  vercel_deployment_target     = "production"
-  environment_name_suffix      = local.is_production ? "" : "-${local.environment_name}"
+  environment_name          = terraform.workspace
+  is_production            = terraform.workspace == "production"
+  environment_name_suffix  = local.is_production ? "" : "-${local.environment_name}"
+  api_domain               = "api${local.environment_name_suffix}.umans.ai"
+  ui_domain                = "app${local.environment_name_suffix}.umans.ai"
   conversational_ui_project_name = "conversational-ui${local.environment_name_suffix}"
-  auth_url                     = "https://${local.ui_domain}"
-  api_url                      = "https://${local.api_domain}"
-  certificate_arn              = data.terraform_remote_state.provision.outputs.certificate_arn
+  auth_url                 = "https://${local.ui_domain}"
+  api_url                  = "https://${local.api_domain}"
+  certificate_arn          = data.terraform_remote_state.provision.outputs.certificate_arn
+  deployment_target        = local.is_production ? "production" : "preview"
+  vercel_deployment_target = "production"
 }
 
 # Commenting out the certificate lookup as we'll use the hardcoded ARN

--- a/operations/02-deploy/main.tf
+++ b/operations/02-deploy/main.tf
@@ -20,19 +20,19 @@ locals {
   deployment_target              = terraform.workspace == "production" ? "production" : "preview"
   vercel_deployment_target       = "production"
   environment_name_suffix        = terraform.workspace == "production" ? "" : "-${local.environment_name}"
-  domain_prefix                 = terraform.workspace == "production" ? "" : "${local.environment_name}."
+  domain_prefix                  = terraform.workspace == "production" ? "" : "${local.environment_name}."
   conversational_ui_project_name = "conversational-ui${local.environment_name_suffix}"
   auth_url                       = "https://app.${local.domain_prefix}umans.ai"
+  api_url                        = "https://api.${local.domain_prefix}umans.ai"
   
-  # Verify that certificate validation has been completed
-  # This will cause Terraform to fail if the certificate is not validated
-  certificate_validation_check = data.terraform_remote_state.provision.outputs.certificate_validation_status == "Certificate validation completed. You can now deploy the API domain." ? true : tobool("Certificate not validated yet. Please ensure DNS records are created and wait for validation to complete.")
+  # Use certificate ARN from the provision layer
+  certificate_arn = data.terraform_remote_state.provision.outputs.certificate_arn
 }
 
-# Explicitly query the certificate to verify it's validated
-data "aws_acm_certificate" "umans_ai" {
-  domain      = "*.umans.ai"  # Explicitly query for the wildcard cert
-  statuses    = ["ISSUED"]
-  types       = ["AMAZON_ISSUED"]
-  most_recent = true
-}
+# Commenting out the certificate lookup as we'll use the hardcoded ARN
+# data "aws_acm_certificate" "umans_ai" {
+#   domain      = "umans.ai"  # Search for the exact domain
+#   statuses    = ["ISSUED"]
+#   types       = ["AMAZON_ISSUED"]
+#   most_recent = true
+# }

--- a/operations/02-deploy/outputs.tf
+++ b/operations/02-deploy/outputs.tf
@@ -21,7 +21,7 @@ output "api_domain_url" {
 # Information for Namecheap DNS configuration
 output "api_domain_cname_target" {
   value       = aws_apigatewayv2_domain_name.api_domain.domain_name_configuration[0].target_domain_name
-  description = "CNAME value to configure in Namecheap for api.umans.ai"
+  description = "CNAME value to configure in Namecheap for the API domain"
 }
 
 output "api_gateway_endpoint" {
@@ -37,7 +37,7 @@ output "namecheap_dns_instructions" {
     To configure the API domain, add this record in Namecheap Advanced DNS:
     
     Type: CNAME
-    Host: ${terraform.workspace == "production" ? "api" : "api${local.domain_prefix}"}
+    Host: ${local.api_domain != "api.umans.ai" ? replace(local.api_domain, ".umans.ai", "") : "api"}
     Value: ${aws_apigatewayv2_domain_name.api_domain.domain_name_configuration[0].target_domain_name}
     TTL: Automatic
 

--- a/operations/02-deploy/outputs.tf
+++ b/operations/02-deploy/outputs.tf
@@ -12,3 +12,13 @@ output "process_queue_url" {
   value       = aws_sqs_queue.process_queue.url
   description = "URL of the SQS queue for repository processing"
 }
+
+output "api_domain_url" {
+  value       = "https://api.${local.domain_prefix}umans.ai"
+  description = "URL of the custom domain for the API"
+}
+
+output "api_gateway_endpoint" {
+  value       = aws_apigatewayv2_api.cudu_api.api_endpoint
+  description = "URL of the API Gateway endpoint"
+}

--- a/operations/02-deploy/outputs.tf
+++ b/operations/02-deploy/outputs.tf
@@ -37,7 +37,7 @@ output "namecheap_dns_instructions" {
     To configure the API domain, add this record in Namecheap Advanced DNS:
     
     Type: CNAME
-    Host: ${local.api_domain != "api.umans.ai" ? replace(local.api_domain, ".umans.ai", "") : "api"}
+    Host: ${replace(local.api_domain, ".umans.ai", "")}
     Value: ${aws_apigatewayv2_domain_name.api_domain.domain_name_configuration[0].target_domain_name}
     TTL: Automatic
 

--- a/operations/02-deploy/outputs.tf
+++ b/operations/02-deploy/outputs.tf
@@ -13,16 +13,14 @@ output "process_queue_url" {
   description = "URL of the SQS queue for repository processing"
 }
 
+# Temporarilly commented out since we're not creating the custom domain yet
+/*
 output "api_domain_url" {
   value       = "https://api.${local.domain_prefix}umans.ai"
   description = "URL of the custom domain for the API"
 }
 
-output "api_gateway_endpoint" {
-  value       = aws_apigatewayv2_api.cudu_api.api_endpoint
-  description = "URL of the API Gateway endpoint"
-}
-
+# Information for Namecheap DNS configuration
 output "api_domain_cname_target" {
   value       = aws_apigatewayv2_domain_name.api_domain.domain_name_configuration[0].target_domain_name
   description = "CNAME value to configure in Namecheap for api.umans.ai"
@@ -44,4 +42,11 @@ output "namecheap_dns_instructions" {
     a few minutes to a few hours are sufficient.
   EOT
   description = "Instructions for DNS configuration in Namecheap"
+}
+*/
+
+# Temporary output for the API Gateway URL until we get the custom domain working
+output "api_gateway_endpoint" {
+  value       = aws_apigatewayv2_stage.cudu_api.invoke_url
+  description = "URL of the API Gateway endpoint"
 }

--- a/operations/02-deploy/outputs.tf
+++ b/operations/02-deploy/outputs.tf
@@ -22,3 +22,26 @@ output "api_gateway_endpoint" {
   value       = aws_apigatewayv2_api.cudu_api.api_endpoint
   description = "URL of the API Gateway endpoint"
 }
+
+output "api_domain_cname_target" {
+  value       = aws_apigatewayv2_domain_name.api_domain.domain_name_configuration[0].target_domain_name
+  description = "CNAME value to configure in Namecheap for api.umans.ai"
+}
+
+output "namecheap_dns_instructions" {
+  value = <<-EOT
+    DNS INSTRUCTIONS FOR NAMECHEAP:
+    ----------------------------------
+    
+    To configure the API domain, add this record in Namecheap Advanced DNS:
+    
+    Type: CNAME
+    Host: api${local.environment_name == "production" ? "" : ".${local.environment_name}"}
+    Value: ${aws_apigatewayv2_domain_name.api_domain.domain_name_configuration[0].target_domain_name}
+    TTL: Automatic
+
+    DNS propagation can take up to 48 hours, but usually 
+    a few minutes to a few hours are sufficient.
+  EOT
+  description = "Instructions for DNS configuration in Namecheap"
+}

--- a/operations/02-deploy/outputs.tf
+++ b/operations/02-deploy/outputs.tf
@@ -14,7 +14,7 @@ output "process_queue_url" {
 }
 
 output "api_domain_url" {
-  value       = "https://api.${local.domain_prefix}umans.ai"
+  value       = local.api_url
   description = "URL of the custom domain for the API"
 }
 
@@ -37,7 +37,7 @@ output "namecheap_dns_instructions" {
     To configure the API domain, add this record in Namecheap Advanced DNS:
     
     Type: CNAME
-    Host: api${local.environment_name == "production" ? "" : ".${local.environment_name}"}
+    Host: ${terraform.workspace == "production" ? "api" : "api${local.domain_prefix}"}
     Value: ${aws_apigatewayv2_domain_name.api_domain.domain_name_configuration[0].target_domain_name}
     TTL: Automatic
 

--- a/operations/02-deploy/outputs.tf
+++ b/operations/02-deploy/outputs.tf
@@ -13,8 +13,6 @@ output "process_queue_url" {
   description = "URL of the SQS queue for repository processing"
 }
 
-# Temporarilly commented out since we're not creating the custom domain yet
-/*
 output "api_domain_url" {
   value       = "https://api.${local.domain_prefix}umans.ai"
   description = "URL of the custom domain for the API"
@@ -24,6 +22,11 @@ output "api_domain_url" {
 output "api_domain_cname_target" {
   value       = aws_apigatewayv2_domain_name.api_domain.domain_name_configuration[0].target_domain_name
   description = "CNAME value to configure in Namecheap for api.umans.ai"
+}
+
+output "api_gateway_endpoint" {
+  value       = aws_apigatewayv2_stage.cudu_api.invoke_url
+  description = "URL of the API Gateway endpoint"
 }
 
 output "namecheap_dns_instructions" {
@@ -42,11 +45,4 @@ output "namecheap_dns_instructions" {
     a few minutes to a few hours are sufficient.
   EOT
   description = "Instructions for DNS configuration in Namecheap"
-}
-*/
-
-# Temporary output for the API Gateway URL until we get the custom domain working
-output "api_gateway_endpoint" {
-  value       = aws_apigatewayv2_stage.cudu_api.invoke_url
-  description = "URL of the API Gateway endpoint"
 }

--- a/operations/02-deploy/webapi.tf
+++ b/operations/02-deploy/webapi.tf
@@ -83,7 +83,7 @@ resource "aws_apigatewayv2_stage" "cudu_api" {
 
 # Custom domain name for API Gateway
 resource "aws_apigatewayv2_domain_name" "api_domain" {
-  domain_name = "api.${local.domain_prefix}umans.ai"
+  domain_name = local.api_domain
 
   domain_name_configuration {
     certificate_arn = local.certificate_arn
@@ -93,7 +93,7 @@ resource "aws_apigatewayv2_domain_name" "api_domain" {
 
   # Add tags to help with debugging
   tags = {
-    Name = "api.${local.domain_prefix}umans.ai"
+    Name = local.api_domain
     Environment = local.environment_name
     ManagedBy = "Terraform"
   }

--- a/operations/02-deploy/webapi.tf
+++ b/operations/02-deploy/webapi.tf
@@ -81,7 +81,7 @@ resource "aws_apigatewayv2_stage" "cudu_api" {
   auto_deploy = true
 }
 
-# Domaine personnalisé pour API Gateway
+# Custom domain name for API Gateway
 resource "aws_apigatewayv2_domain_name" "api_domain" {
   domain_name = "api.${local.domain_prefix}umans.ai"
 
@@ -92,24 +92,11 @@ resource "aws_apigatewayv2_domain_name" "api_domain" {
   }
 }
 
-# Mapping du domaine personnalisé au stage API Gateway
+# Custom domain mapping to API Gateway stage
 resource "aws_apigatewayv2_api_mapping" "api_mapping" {
   api_id      = aws_apigatewayv2_api.cudu_api.id
   domain_name = aws_apigatewayv2_domain_name.api_domain.id
   stage       = aws_apigatewayv2_stage.cudu_api.id
-}
-
-# Enregistrement DNS pour le domaine personnalisé de l'API
-resource "aws_route53_record" "api_domain" {
-  name    = "api.${local.domain_prefix}umans.ai"
-  type    = "A"
-  zone_id = data.terraform_remote_state.provision.outputs.hosted_zone_id
-
-  alias {
-    name                   = aws_apigatewayv2_domain_name.api_domain.domain_name_configuration[0].target_domain_name
-    zone_id                = aws_apigatewayv2_domain_name.api_domain.domain_name_configuration[0].hosted_zone_id
-    evaluate_target_health = false
-  }
 }
 
 # Lambda permission for API Gateway

--- a/operations/02-deploy/webapi.tf
+++ b/operations/02-deploy/webapi.tf
@@ -91,7 +91,6 @@ resource "aws_apigatewayv2_domain_name" "api_domain" {
     security_policy = "TLS_1_2"
   }
 
-  # Add tags to help with debugging
   tags = {
     Name = local.api_domain
     Environment = local.environment_name

--- a/operations/02-deploy/webapi.tf
+++ b/operations/02-deploy/webapi.tf
@@ -86,7 +86,7 @@ resource "aws_apigatewayv2_domain_name" "api_domain" {
   domain_name = "api.${local.domain_prefix}umans.ai"
 
   domain_name_configuration {
-    certificate_arn = data.terraform_remote_state.provision.outputs.certificate_arn
+    certificate_arn = data.aws_acm_certificate.umans_ai.arn
     endpoint_type   = "REGIONAL"
     security_policy = "TLS_1_2"
   }


### PR DESCRIPTION
This pull request introduces infrastructure changes to set up a custom domain (`umans.ai`) and SSL certificate for the API, along with updates to DNS and API Gateway configurations. These changes enhance the deployment by providing a secure and user-friendly domain for the API.

### Custom Domain and SSL Certificate Setup:
* Added a Route53 hosted zone for `umans.ai` and an ACM certificate for `*.umans.ai` to enable secure communication. Included DNS validation for the certificate and its validation process. (`operations/01-provision/dns-and-certificates.tf`, [operations/01-provision/dns-and-certificates.tfR1-R39](diffhunk://#diff-bde6a7b9fe523ca177d8c4bfc1b93f4418d58f3366cbe83bdc15cca7b51436beR1-R39))
* Introduced outputs for the certificate ARN and hosted zone ID to make them accessible for other modules. (`operations/01-provision/output.tf`, [operations/01-provision/output.tfR41-R50](diffhunk://#diff-a89db30cdc3e429a22a76188f68c1473c0d93d0c7b0e4301dabd026a3c0c0d7eR41-R50))

### API Gateway Custom Domain Configuration:
* Configured a custom domain (`api.${local.domain_prefix}umans.ai`) for the API Gateway, mapped it to the API stage, and added a Route53 DNS record for the custom domain. (`operations/02-deploy/webapi.tf`, [operations/02-deploy/webapi.tfR84-R114](diffhunk://#diff-fbe099563bd171e4a330e673e2f40e1bd19c4c781c5e23bafd6369af8150d379R84-R114))

### API Endpoint Updates:
* Updated the API endpoint in the Vercel environment variables to use the new custom domain (`https://api.${local.domain_prefix}umans.ai`). (`operations/02-deploy/conversational-ui.tf`, [operations/02-deploy/conversational-ui.tfL118-R118](diffhunk://#diff-9b749660ad5404511da017e291a9fa5b349b6a990e069f320e0ff1a86eecfc50L118-R118))
* Added outputs for the custom API domain URL and the original API Gateway endpoint for better visibility. (`operations/02-deploy/outputs.tf`, [operations/02-deploy/outputs.tfR15-R24](diffhunk://#diff-5097a4658df3642ff455999366e8cab4547373140d4f1763b49bfb9165335061R15-R24))