### PR TITLE
Fix pgbouncer prepared statement errors

### DIFF
--- a/issue-solver/src/issue_solver/database/migrations/env.py
+++ b/issue-solver/src/issue_solver/database/migrations/env.py
@@ -1,12 +1,13 @@
 import asyncio
 import os
 from logging.config import fileConfig
-from itertools import count
 
 from alembic import context
 from sqlalchemy import pool
 from sqlalchemy.engine import Connection
 from sqlalchemy.ext.asyncio import create_async_engine
+
+from issue_solver.database.utils import get_sqlalchemy_connect_args
 
 # this is the Alembic Config object, which provides
 # access to values within the .ini file in use.
@@ -23,9 +24,6 @@ if config.config_file_name is not None:
 # from myapp.db.models import Base
 # target_metadata = Base.metadata
 target_metadata = None
-
-# Counter for generating unique prepared statement names
-_stmt_counter = count()
 
 
 def run_migrations_offline() -> None:
@@ -67,15 +65,7 @@ async def run_migrations_online() -> None:
     connectable = create_async_engine(
         db_url,
         poolclass=pool.NullPool,
-        connect_args={
-            "statement_cache_size": 0,
-            "prepared_statement_cache_size": 0,
-            "prepared_statement_name_func": lambda operation=None: f"ps_{next(_stmt_counter)}",
-            "server_settings": {
-                "statement_timeout": "10000",
-                "idle_in_transaction_session_timeout": "60000",
-            },
-        },
+        connect_args=get_sqlalchemy_connect_args(),
     )
 
     async with connectable.connect() as async_connection:

--- a/issue-solver/src/issue_solver/database/utils.py
+++ b/issue-solver/src/issue_solver/database/utils.py
@@ -1,0 +1,45 @@
+"""Utility functions for database connections."""
+from itertools import count
+from typing import Any, Callable, Dict, Optional
+
+# Counter for generating unique prepared statement names
+_stmt_counter = count()
+
+
+def get_pgbouncer_safe_connect_args(
+    statement_name_prefix: str = "ps"
+) -> Dict[str, Any]:
+    """
+    Return connection arguments for pgbouncer compatibility.
+    
+    This prevents the 'prepared statement "ps_xx" already exists' error
+    when using pgbouncer in transaction pooling mode.
+    
+    Args:
+        statement_name_prefix: Prefix to use for prepared statements
+    
+    Returns:
+        Dictionary with connection arguments
+    """
+    return {
+        "statement_cache_size": 0,
+        "prepared_statement_cache_size": 0,
+        "prepared_statement_name_func": lambda operation=None: f"{statement_name_prefix}_{next(_stmt_counter)}",
+        "server_settings": {
+            "statement_timeout": "10000",  # 10 seconds
+            "idle_in_transaction_session_timeout": "60000",  # 60 seconds
+        },
+    }
+
+
+def get_sqlalchemy_connect_args() -> Dict[str, Any]:
+    """
+    Return connection arguments for SQLAlchemy engines.
+    
+    This is a wrapper around get_pgbouncer_safe_connect_args,
+    with any SQLAlchemy-specific settings.
+    
+    Returns:
+        Dictionary with connection arguments for SQLAlchemy
+    """
+    return get_pgbouncer_safe_connect_args()

--- a/issue-solver/src/issue_solver/webapi/dependencies.py
+++ b/issue-solver/src/issue_solver/webapi/dependencies.py
@@ -8,6 +8,7 @@ from issue_solver.agents.coding_agent import CodingAgent
 from issue_solver.agents.openai_agent import OpenAIAgent
 from issue_solver.clock import Clock, UTCSystemClock
 from issue_solver.database.postgres_event_store import PostgresEventStore
+from issue_solver.database.utils import get_pgbouncer_safe_connect_args
 from issue_solver.events.event_store import EventStore
 from issue_solver.git_operations.git_helper import (
     DefaultGitValidationService,
@@ -53,6 +54,7 @@ def get_validation_service() -> GitValidationService:
 async def init_event_store() -> EventStore:
     return PostgresEventStore(
         connection=await asyncpg.connect(
-            os.environ["DATABASE_URL"].replace("+asyncpg", ""), statement_cache_size=0
+            os.environ["DATABASE_URL"].replace("+asyncpg", ""),
+            **get_pgbouncer_safe_connect_args()
         )
     )

--- a/issue-solver/tests/database/conftest.py
+++ b/issue-solver/tests/database/conftest.py
@@ -8,6 +8,7 @@ import pytest
 import pytest_asyncio
 from alembic.command import downgrade, upgrade
 from alembic.config import Config
+from issue_solver.database.utils import get_pgbouncer_safe_connect_args
 from issue_solver.events.event_store import EventStore
 from issue_solver.webapi.dependencies import init_event_store
 from testcontainers.postgres import PostgresContainer
@@ -35,7 +36,10 @@ def wait_for_postgres(db_url: str, timeout: int = 5) -> None:
 
 
 async def _check_connection(db_url: str) -> None:
-    conn = await asyncpg.connect(db_url)
+    conn = await asyncpg.connect(
+        db_url,
+        **get_pgbouncer_safe_connect_args()
+    )
     await conn.execute("SELECT 1")
     await conn.close()
 

--- a/issue-solver/tests/webapi/conftest.py
+++ b/issue-solver/tests/webapi/conftest.py
@@ -9,6 +9,7 @@ import boto3
 import pytest
 from alembic.command import downgrade, upgrade
 from alembic.config import Config
+from issue_solver.database.utils import get_pgbouncer_safe_connect_args
 from issue_solver.webapi.dependencies import get_clock, get_validation_service
 from issue_solver.webapi.main import app
 from pytest_httpserver import HTTPServer
@@ -105,7 +106,10 @@ def wait_for_postgres(db_url: str, timeout: int = 5) -> None:
 
 
 async def _check_connection(db_url: str) -> None:
-    conn = await asyncpg.connect(db_url)
+    conn = await asyncpg.connect(
+        db_url,
+        **get_pgbouncer_safe_connect_args()
+    )
     await conn.execute("SELECT 1")
     await conn.close()
 


### PR DESCRIPTION
When running database migrations with `uv run alembic upgrade head`, we sometimes encounter the error `asyncpg.exceptions.DuplicatePreparedStatementError: prepared statement "ps_2" already exists`. This happens because we're using pgbouncer with a connection pooling mode that doesn't properly support prepared statements.

The solution is to consistently set `statement_cache_size=0` and other related parameters across all database connections in our application.

Specifically:
1. Ensure all direct asyncpg connections include `statement_cache_size=0`
2. Ensure all SQLAlchemy engine creation includes the necessary connect_args
3. Make sure our Alembic configuration is consistent with these settings

We already have this configuration in some places (like in dependencies.py and env.py), but we need to make it consistent across the codebase.