### PR TITLE
Fix Alembic migrations hanging in CI/CD workflows

### DIFF
--- a/.github/workflows/cd-workflow.yml
+++ b/.github/workflows/cd-workflow.yml
@@ -198,7 +198,7 @@ jobs:
           cd operations/01-provision
           terraform init -reconfigure
           just init
-          export DATABASE_URL=$(just backend-database-url)
+          export DATABASE_URL=$(just backend-direct-database-url)
           cd ../../issue-solver
           uv sync
           just db-upgrade

--- a/operations/01-provision/justfile
+++ b/operations/01-provision/justfile
@@ -54,9 +54,13 @@ destroy: init empty-bucket
     @terraform destroy -var "branch_name={{ branch_name }}" -auto-approve
     @echo ">>> Destroyed all resources for branch '{{ branch_name }}'."
 
-# 👀 Show BACKEND_DATABASE_URL.
+# 👀 Show BACKEND_DATABASE_URL for normal operations (using PgBouncer).
 backend-database-url:
     @echo "$(terraform output -raw transaction_pooler_connection_string | sed 's/postgresql:\/\//postgresql+asyncpg:\/\//g' | sed 's/\?.*//g')"
+
+# 👀 Show BACKEND_DATABASE_URL for direct connections (bypassing PgBouncer, for migrations).
+backend-direct-database-url:
+    @echo "$(terraform output -raw direct_database_connection_string | sed 's/postgresql:\/\//postgresql+asyncpg:\/\//g')&ssl=true"
 
 # 👀 Show FRONTEND_DATABASE_URL.
 frontend-database-url:

--- a/operations/01-provision/output.tf
+++ b/operations/01-provision/output.tf
@@ -9,6 +9,16 @@ output "transaction_pooler_connection_string" {
   sensitive = true
 }
 
+output "direct_database_connection_string" {
+  description = "Direct database connection string (bypassing PgBouncer) for migrations"
+  value = format(
+    "postgresql://postgres:%s@db.%s.supabase.co:5432/postgres?sslmode=require",
+    random_password.conversational_ui_db_password.result,
+    supabase_project.conversational_ui.id
+  )
+  sensitive = true
+}
+
 output "transaction_pooler_jdbc_connection_string" {
   description = "JDBC connection string for transaction pooler"
   value = format(


### PR DESCRIPTION
Currently, Alembic migrations are hanging in CI/CD workflows, likely due to connection issues with PgBouncer when using asyncpg. The solution is to use a direct database connection URL for migrations in CI/CD instead of the pooled connection.

Implementation steps:

1. Add a direct connection string output to the Terraform configuration in operations/01-provision/output.tf
2. Add a backend-direct-database-url command to the justfile in operations/01-provision
3. Update the CI/CD workflow to use the direct connection URL for migrations
4. Modify the Alembic environment script to handle SSL connections properly

The direct connection should use:
- 'postgres' as the username (not 'postgres.{project_id}')
- The direct database host 'db.{project_id}.supabase.co'
- 'ssl=true' parameter compatible with asyncpg
- The correct format for asyncpg connections