### PR TITLE
Fix Terraform files (.tf) not indexed by codebase search

### DIFF
--- a/issue-solver/src/issue_solver/worker/vector_store_helper.py
+++ b/issue-solver/src/issue_solver/worker/vector_store_helper.py
@@ -41,6 +41,7 @@ SUPPORTED_EXTENSIONS = {
     ".py",
     ".rb",
     ".tex",
+    ".tf",
     ".ts",
     ".txt",
     ".webp",


### PR DESCRIPTION
## Description

The codebase search functionality is not finding Terraform (`.tf`) files when searching the codebase. This appears to be because Terraform files are not being properly indexed during the repository indexing process.

The issue is in the `vector_store_helper.py` file. The `SUPPORTED_EXTENSIONS` set defines which file extensions are natively supported for indexing, but it doesn't include the `.tf` extension for Terraform files.

## Current Behavior

When using the codebase search tool to search for content that exists in Terraform files, no results are returned from those files, making it impossible to find or reference Terraform code through the conversational agent.

## Expected Behavior

Terraform files (`.tf`) should be indexed and searchable like other code files in the repository.

## Proposed Solution

Add `.tf` extension to the `SUPPORTED_EXTENSIONS` set in `vector_store_helper.py`.

This PR closes issue #108.