### PR TITLE
Fix MessageEditor empty textarea by extracting content from message.parts

### DIFF
--- a/conversational-ui/components/message-editor.tsx
+++ b/conversational-ui/components/message-editor.tsx
@@ -22,7 +22,14 @@ export function MessageEditor({
 }: MessageEditorProps) {
   const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
 
-  const [draftContent, setDraftContent] = useState<string>(message.content);
+  const [draftContent, setDraftContent] = useState<string>(() => {
+    const textParts = message.parts
+      ?.filter((part) => part.type === 'text')
+      .map((part) => part.text)
+      .join('\n')
+      .trim();
+    return textParts || '';
+  });
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   useEffect(() => {


### PR DESCRIPTION
## Problem

The MessageEditor component initializes with `message.content` which is always empty after the migration to the new Message_v2 schema. The actual message content is stored in `message.parts` array.

## Root Cause

In `/conversational-ui/components/message-editor.tsx`, line 25:
```typescript
const [draftContent, setDraftContent] = useState<string>(message.content);
```

This uses `message.content` which is always an empty string in the new schema. The actual content is in `message.parts[].text`.

## Solution

Extract the text content from `message.parts` array, similar to how the copy functionality works in `message.tsx`:

```typescript
const [draftContent, setDraftContent] = useState<string>(() => {
  const textParts = message.parts
    ?.filter((part) => part.type === 'text')
    .map((part) => part.text)
    .join('\n')
    .trim();
  return textParts || '';
});
```

## Files to Change

- `/conversational-ui/components/message-editor.tsx` - Fix the useState initialization

## Expected Behavior

- When clicking edit on a message, the textarea should display the original message content
- Users should be able to edit and save their messages properly
- This should work consistently after page refresh

## Testing

1. Send a chat message
2. Refresh the page
3. Click the edit button (pencil icon) on the message
4. Verify the textarea displays the original message content
5. Edit the content and save
6. Verify the message is updated correctly