### PR TITLE
Fix missing animation for GitHub MCP tools in partial-call state

### DIFF
--- a/conversational-ui/components/github-mcp/github-mcp-result.tsx
+++ b/conversational-ui/components/github-mcp/github-mcp-result.tsx
@@ -196,6 +196,10 @@ const GitHubIssuesResult = ({ toolName, result, args }: GitHubMCPResultProps) =>
       return <GitHubIssuesList issues={result} repository={`${args?.owner}/${args?.repo}`} />;
     case 'get_issue':
       return <GitHubIssueDetail issue={result} />;
+    case 'create_issue':
+      return <GitHubIssueDetail issue={result} />;
+    case 'update_issue':
+      return <GitHubIssueDetail issue={result} />;
     case 'search_issues':
       return <GitHubIssuesList issues={result} repository="search results" />;
     default:

--- a/conversational-ui/components/message.tsx
+++ b/conversational-ui/components/message.tsx
@@ -289,6 +289,8 @@ const PurePreviewMessage = ({
                       issueDescription={issueDescription}
                       result={null}
                     />
+                  ) : isGitHubMCPTool(toolName) ? (
+                    <GitHubMCPAnimation toolName={toolName} args={args} />
                   ) : null;
                 }
 


### PR DESCRIPTION
## Problem
When updating GitHub issues using GitHub MCP tools, there's no animation displayed during the partial-call state, creating a poor user experience where users see no feedback while the operation is in progress.

## Current Behavior
In the message.tsx component, the partial-call state only handles remoteCodingAgent tool:

```typescript
if (state === 'partial-call') {
  const { args } = toolInvocation;
  const issueTitle = args?.issue?.title ?? '';
  const issueDescription = args?.issue?.description ?? '';

  return toolName === 'remoteCodingAgent' ? (
    <RemoteCodingStream
      key={toolCallId}
      toolCallId={toolCallId}
      issueTitle={issueTitle}
      issueDescription={issueDescription}
      result={null}
    />
  ) : null; // ❌ GitHub MCP tools return null - no animation
}
```

## Expected Behavior
GitHub MCP tools (like update_issue, create_issue, add_issue_comment, etc.) should display an appropriate animation during the partial-call state, similar to how they work in the call state.

## Technical Context
**Current Implementation:**
- call state: ✅ Shows GitHubMCPAnimation component
- partial-call state: ❌ Returns null for GitHub MCP tools
- result state: ✅ Shows GitHubMCPResult component

**Architecture:**
The system uses a proxy pattern where:
- Conversational UI → Issue-Solver proxy → GitHub Remote MCP → GitHub API
- GitHub tokens remain secure in Issue-Solver subsystem
- Rich UI components provide contextual feedback

## Proposed Solution
Add GitHub MCP tool handling to the partial-call state:

```typescript
if (state === 'partial-call') {
  const { args } = toolInvocation;
  const issueTitle = args?.issue?.title ?? '';
  const issueDescription = args?.issue?.description ?? '';

  return toolName === 'remoteCodingAgent' ? (
    <RemoteCodingStream
      key={toolCallId}
      toolCallId={toolCallId}
      issueTitle={issueTitle}
      issueDescription={issueDescription}
      result={null}
    />
  ) : isGitHubMCPTool(toolName) ? (
    <GitHubMCPAnimation toolName={toolName} args={args} />
  ) : null;
}
```

## Impact
- **User Experience:** Users currently see no feedback during GitHub operations, making the interface feel unresponsive.
- **Consistency:** Other tools (weather, webSearch, remoteCodingAgent) all have proper partial-call animations.

## Files Affected
- `/conversational-ui/components/message.tsx` (line ~150-160)
- Existing GitHubMCPAnimation component can be reused

## Acceptance Criteria
- ✅ GitHub MCP tools show animation during partial-call state
- ✅ Animation text reflects the specific operation (e.g., "Updating issue #123")
- ✅ Consistent with existing animation patterns
- ✅ No regression in call and result state handling

## Additional Request
Ensure that when a ticket is created it shows up in the same way consistently as when we list an issue - maintaining visual consistency across GitHub issue operations.

## Priority
Medium - Affects user experience but doesn't break functionality

## Labels
- bug
- ui/ux
- github-mcp
- good-first-issue