### PR TITLE
Fix inconsistent copy button behavior between user and assistant messages

### DIFF
--- a/conversational-ui/components/message.tsx
+++ b/conversational-ui/components/message.tsx
@@ -4,6 +4,7 @@ import type { UIMessage } from 'ai';
 import cx from 'classnames';
 import { AnimatePresence, motion } from 'framer-motion';
 import { memo, useMemo, useState, useEffect } from 'react';
+import { toast } from 'sonner';
 
 import type { Vote } from '@/lib/db/schema';
 
@@ -193,10 +194,12 @@ const PurePreviewMessage = ({
                                     .trim();
 
                                   if (!textFromParts) {
+                                    toast.error("There's no text to copy!");
                                     return;
                                   }
 
                                   await navigator.clipboard.writeText(textFromParts);
+                                  toast.success('Copied to clipboard!');
                                 }}
                               >
                                 <Copy />


### PR DESCRIPTION
## Bug Description

There is an inconsistency between the copy button behavior for assistant messages and user messages. Currently, when a user copies an assistant message, they receive feedback via a toast notification, but when copying their own messages, no feedback is provided.

### Current Behavior

**Assistant Messages Copy Button** (in `message-actions.tsx`):
```javascript
await copyToClipboard(textFromParts);
toast.success('Copied to clipboard!');
```

**User Messages Copy Button** (in `message.tsx`):
```javascript
await navigator.clipboard.writeText(textFromParts);
// No toast notification
```

### Expected Behavior

Both copy buttons should behave consistently:
- Both should provide feedback when content is copied
- A toast notification should appear in both cases
- Error handling should be consistent (e.g., showing an error toast if there's no text to copy)

## Technical Details

### Files Affected
- `/conversational-ui/components/message.tsx` - Contains the user message copy button implementation
- `/conversational-ui/components/message-actions.tsx` - Contains the assistant message copy button implementation

### Proposed Solution

Update the user message copy button in `message.tsx` to match the assistant message behavior:

```javascript
onClick={async () => {
  const textFromParts = message.parts
    ?.filter((part) => part.type === 'text')
    .map((part) => part.text)
    .join('\n')
    .trim();

  if (!textFromParts) {
    toast.error("There's no text to copy!");
    return;
  }

  await navigator.clipboard.writeText(textFromParts);
  toast.success('Copied to clipboard!');
}}
```

## Additional Context

This change would align with other copy actions in the codebase (code blocks, repository URLs, etc.) which already use toast notifications for user feedback. It improves the user experience by providing consistent feedback across the application.