### PR TITLE
Fix remoteCodingAgent tool JSON parsing error

### DIFF
--- a/conversational-ui/lib/ai/tools/remote-coding-agent.ts
+++ b/conversational-ui/lib/ai/tools/remote-coding-agent.ts
@@ -14,7 +14,7 @@ const issueSchema = z.object({
 });
 
 export const remoteCodingAgent = ({ session }: RemoteCodingAgentProps) => tool({
-    description: "A tool for that launch a remote instance of a coding agent to resolve an issue by submitting a PR/MR.",
+    description: "A tool that launches a remote instance of a coding agent to resolve an issue by submitting a PR/MR.",
     parameters: z.object({
         issue: issueSchema,
     }),

--- a/conversational-ui/lib/ai/tools/remote-coding-agent.ts
+++ b/conversational-ui/lib/ai/tools/remote-coding-agent.ts
@@ -9,12 +9,12 @@ interface RemoteCodingAgentProps {
 }
 
 const issueSchema = z.object({
-    title: z.string().optional().describe('The title of the issue to be resolved.'),
-    description: z.string().describe('The description of the issue to be resolved.'),
+    title: z.string().optional().describe('The title of the issue to be resolved. Must be a JSON string value.'),
+    description: z.string().describe('The description of the issue to be resolved. Must be a JSON string value.'),
 });
 
 export const remoteCodingAgent = ({ session }: RemoteCodingAgentProps) => tool({
-    description: "A tool that launches a remote instance of a coding agent to resolve an issue by submitting a PR/MR.",
+    description: "A tool that launches a remote instance of a coding agent to resolve an issue by submitting a PR/MR. IMPORTANT: Use strict JSON format for parameters. Example: {\"issue\": {\"title\": \"Fix bug in authentication\", \"description\": \"The login form shows incorrect error messages\"}}",
     parameters: z.object({
         issue: issueSchema,
     }),


### PR DESCRIPTION
The remoteCodingAgent tool is failing with a JSON parsing error due to malformed parameter format during fine-grained tool streaming with Anthropic models. The model is incorrectly using XML-like parameter syntax instead of the expected JSON format.

As recommended in issue #114, we need to enhance the tool description with explicit JSON schema guidance to instruct the model to use strict JSON format for parameters.

The fix involves updating the tool description in `/conversational-ui/lib/ai/tools/remote-coding-agent.ts` to include explicit JSON schema examples and formatting instructions.