### PR TITLE
Add Token Tracking to Conversational UI Chat

### DIFF
--- a/conversational-ui/lib/db/migrations/0014_token_usage_table.sql
+++ b/conversational-ui/lib/db/migrations/0014_token_usage_table.sql
@@ -1,0 +1,37 @@
+CREATE TABLE IF NOT EXISTS "TokenUsage" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"chatId" uuid NOT NULL,
+	"userId" uuid NOT NULL,
+	"spaceId" uuid,
+	"model" varchar(255) NOT NULL,
+	"provider" varchar(100) NOT NULL,
+	"promptTokens" integer,
+	"completionTokens" integer,
+	"totalTokens" integer,
+	"reasoningTokens" integer,
+	"thinkingTokens" integer,
+	"thinkingBudgetTokens" integer,
+	"cachedTokens" integer,
+	"cacheCreationTokens" integer,
+	"cacheReadTokens" integer,
+	"rawUsageData" json,
+	"createdAt" timestamp DEFAULT now() NOT NULL
+);
+
+DO $$ BEGIN
+ ALTER TABLE "TokenUsage" ADD CONSTRAINT "TokenUsage_chatId_Chat_id_fk" FOREIGN KEY ("chatId") REFERENCES "Chat"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+
+DO $$ BEGIN
+ ALTER TABLE "TokenUsage" ADD CONSTRAINT "TokenUsage_userId_User_id_fk" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+
+DO $$ BEGIN
+ ALTER TABLE "TokenUsage" ADD CONSTRAINT "TokenUsage_spaceId_Space_id_fk" FOREIGN KEY ("spaceId") REFERENCES "Space"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;

--- a/conversational-ui/lib/db/migrations/meta/0014_snapshot.json
+++ b/conversational-ui/lib/db/migrations/meta/0014_snapshot.json
@@ -1,0 +1,157 @@
+{
+  "id": "0014_token_usage_table",
+  "prevId": "0013_gifted_silver_centurion",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "TokenUsage": {
+      "name": "TokenUsage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chatId": {
+          "name": "chatId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "spaceId": {
+          "name": "spaceId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "promptTokens": {
+          "name": "promptTokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completionTokens": {
+          "name": "completionTokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "totalTokens": {
+          "name": "totalTokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reasoningTokens": {
+          "name": "reasoningTokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thinkingTokens": {
+          "name": "thinkingTokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thinkingBudgetTokens": {
+          "name": "thinkingBudgetTokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cachedTokens": {
+          "name": "cachedTokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cacheCreationTokens": {
+          "name": "cacheCreationTokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cacheReadTokens": {
+          "name": "cacheReadTokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rawUsageData": {
+          "name": "rawUsageData",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "TokenUsage_chatId_Chat_id_fk": {
+          "name": "TokenUsage_chatId_Chat_id_fk",
+          "tableFrom": "TokenUsage",
+          "tableTo": "Chat",
+          "columnsFrom": ["chatId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "TokenUsage_userId_User_id_fk": {
+          "name": "TokenUsage_userId_User_id_fk",
+          "tableFrom": "TokenUsage",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "TokenUsage_spaceId_Space_id_fk": {
+          "name": "TokenUsage_spaceId_Space_id_fk",
+          "tableFrom": "TokenUsage",
+          "tableTo": "Space",
+          "columnsFrom": ["spaceId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/conversational-ui/lib/db/migrations/meta/_journal.json
+++ b/conversational-ui/lib/db/migrations/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1750351007882,
       "tag": "0013_gifted_silver_centurion",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1750351007883,
+      "tag": "0014_token_usage_table",
+      "breakpoints": true
     }
   ]
 }

--- a/conversational-ui/lib/db/queries.ts
+++ b/conversational-ui/lib/db/queries.ts
@@ -18,6 +18,8 @@ import {
   space,
   spaceToUser,
   stream,
+  tokenUsage,
+  type TokenUsage,
 } from './schema';
 import { ArtifactKind } from '@/components/artifact';
 
@@ -793,6 +795,122 @@ export async function updateUserProfile(userId: string, updates: { name?: string
     return await db.update(user).set(updates).where(eq(user.id, userId));
   } catch (error) {
     console.error('Failed to update user profile');
+    throw error;
+  }
+}
+
+// Token usage queries
+
+/**
+ * Save token usage data to database
+ */
+export async function saveTokenUsage(usageData: {
+  chatId: string;
+  userId: string;
+  spaceId?: string;
+  model: string;
+  provider: string;
+  promptTokens?: number;
+  completionTokens?: number;
+  totalTokens?: number;
+  reasoningTokens?: number;
+  thinkingTokens?: number;
+  thinkingBudgetTokens?: number;
+  cachedTokens?: number;
+  cacheCreationTokens?: number;
+  cacheReadTokens?: number;
+  rawUsageData?: any;
+}) {
+  try {
+    return await db.insert(tokenUsage).values({
+      chatId: usageData.chatId,
+      userId: usageData.userId,
+      spaceId: usageData.spaceId,
+      model: usageData.model,
+      provider: usageData.provider,
+      promptTokens: usageData.promptTokens,
+      completionTokens: usageData.completionTokens,
+      totalTokens: usageData.totalTokens,
+      reasoningTokens: usageData.reasoningTokens,
+      thinkingTokens: usageData.thinkingTokens,
+      thinkingBudgetTokens: usageData.thinkingBudgetTokens,
+      cachedTokens: usageData.cachedTokens,
+      cacheCreationTokens: usageData.cacheCreationTokens,
+      cacheReadTokens: usageData.cacheReadTokens,
+      rawUsageData: usageData.rawUsageData,
+    });
+  } catch (error) {
+    console.error('Failed to save token usage:', error);
+    throw error;
+  }
+}
+
+/**
+ * Get token usage by chat ID
+ */
+export async function getTokenUsageByChatId({ chatId }: { chatId: string }) {
+  try {
+    return await db
+      .select()
+      .from(tokenUsage)
+      .where(eq(tokenUsage.chatId, chatId))
+      .orderBy(desc(tokenUsage.createdAt));
+  } catch (error) {
+    console.error('Failed to get token usage by chat ID:', error);
+    throw error;
+  }
+}
+
+/**
+ * Get token usage by user ID
+ */
+export async function getTokenUsageByUserId({ userId }: { userId: string }) {
+  try {
+    return await db
+      .select()
+      .from(tokenUsage)
+      .where(eq(tokenUsage.userId, userId))
+      .orderBy(desc(tokenUsage.createdAt));
+  } catch (error) {
+    console.error('Failed to get token usage by user ID:', error);
+    throw error;
+  }
+}
+
+/**
+ * Get token usage by space ID
+ */
+export async function getTokenUsageBySpaceId({ spaceId }: { spaceId: string }) {
+  try {
+    return await db
+      .select()
+      .from(tokenUsage)
+      .where(eq(tokenUsage.spaceId, spaceId))
+      .orderBy(desc(tokenUsage.createdAt));
+  } catch (error) {
+    console.error('Failed to get token usage by space ID:', error);
+    throw error;
+  }
+}
+
+/**
+ * Get token usage by user ID and space ID
+ */
+export async function getTokenUsageByUserIdAndSpaceId({ 
+  userId, 
+  spaceId 
+}: { 
+  userId: string;
+  spaceId: string;
+}) {
+  try {
+    return await db
+      .select()
+      .from(tokenUsage)
+      .where(and(eq(tokenUsage.userId, userId), eq(tokenUsage.spaceId, spaceId)))
+      .orderBy(desc(tokenUsage.createdAt));
+  } catch (error) {
+    console.error('Failed to get token usage by user and space ID:', error);
     throw error;
   }
 }

--- a/conversational-ui/lib/db/schema.ts
+++ b/conversational-ui/lib/db/schema.ts
@@ -9,6 +9,7 @@ import {
   primaryKey,
   foreignKey,
   boolean,
+  integer,
 } from 'drizzle-orm/pg-core';
 
 export const space = pgTable('Space', {
@@ -205,3 +206,38 @@ export const stream = pgTable(
 );
 
 export type Stream = InferSelectModel<typeof stream>;
+
+export const tokenUsage = pgTable('TokenUsage', {
+  id: uuid('id').primaryKey().notNull().defaultRandom(),
+  chatId: uuid('chatId')
+    .notNull()
+    .references(() => chat.id),
+  userId: uuid('userId')
+    .notNull()
+    .references(() => user.id),
+  spaceId: uuid('spaceId').references(() => space.id),
+  model: varchar('model', { length: 255 }).notNull(),
+  provider: varchar('provider', { length: 100 }).notNull(),
+  
+  // Standard token counts
+  promptTokens: integer('promptTokens'),
+  completionTokens: integer('completionTokens'),
+  totalTokens: integer('totalTokens'),
+  
+  // Provider-specific token counts
+  reasoningTokens: integer('reasoningTokens'), // OpenAI reasoning tokens
+  thinkingTokens: integer('thinkingTokens'), // Anthropic thinking tokens
+  thinkingBudgetTokens: integer('thinkingBudgetTokens'), // Anthropic thinking budget tokens
+  
+  // Caching token counts
+  cachedTokens: integer('cachedTokens'),
+  cacheCreationTokens: integer('cacheCreationTokens'),
+  cacheReadTokens: integer('cacheReadTokens'),
+  
+  // Raw usage data for future analysis
+  rawUsageData: json('rawUsageData'),
+  
+  createdAt: timestamp('createdAt').notNull().defaultNow(),
+});
+
+export type TokenUsage = InferSelectModel<typeof tokenUsage>;

--- a/conversational-ui/lib/token-usage.ts
+++ b/conversational-ui/lib/token-usage.ts
@@ -1,0 +1,158 @@
+import 'server-only';
+
+import { saveTokenUsage as saveTokenUsageQuery } from '@/lib/db/queries';
+
+export interface TokenUsageData {
+  chatId: string;
+  userId: string;
+  spaceId?: string;
+  model: string;
+  provider: string;
+  promptTokens?: number;
+  completionTokens?: number;
+  totalTokens?: number;
+  reasoningTokens?: number;
+  thinkingTokens?: number;
+  thinkingBudgetTokens?: number;
+  cachedTokens?: number;
+  cacheCreationTokens?: number;
+  cacheReadTokens?: number;
+  rawUsageData?: any;
+}
+
+/**
+ * Extract token usage data from AI SDK experimental telemetry
+ */
+export function extractTokenUsage(
+  telemetryData: any,
+  chatId: string,
+  userId: string,
+  spaceId?: string,
+  model?: string,
+  provider?: string
+): TokenUsageData | null {
+  if (!telemetryData || !telemetryData.usage) {
+    return null;
+  }
+
+  const usage = telemetryData.usage;
+  
+  // Extract provider from model if not provided
+  const inferredProvider = provider || inferProviderFromModel(model || '');
+  
+  // Base usage data
+  const baseUsage: TokenUsageData = {
+    chatId,
+    userId,
+    spaceId,
+    model: model || 'unknown',
+    provider: inferredProvider,
+    promptTokens: usage.promptTokens,
+    completionTokens: usage.completionTokens,
+    totalTokens: usage.totalTokens,
+    rawUsageData: usage,
+  };
+
+  // Provider-specific token extraction
+  switch (inferredProvider) {
+    case 'openai':
+      return extractOpenAITokens(usage, baseUsage);
+    
+    case 'anthropic':
+      return extractAnthropicTokens(usage, baseUsage);
+    
+    case 'google':
+      return extractGoogleTokens(usage, baseUsage);
+    
+    default:
+      return baseUsage;
+  }
+}
+
+/**
+ * Extract OpenAI-specific token usage including reasoning tokens
+ */
+function extractOpenAITokens(usage: any, baseUsage: TokenUsageData): TokenUsageData {
+  return {
+    ...baseUsage,
+    reasoningTokens: usage.reasoningTokens,
+    cachedTokens: usage.cachedTokens,
+    cacheCreationTokens: usage.cacheCreationTokens,
+    cacheReadTokens: usage.cacheReadTokens,
+  };
+}
+
+/**
+ * Extract Anthropic-specific token usage including thinking tokens
+ */
+function extractAnthropicTokens(usage: any, baseUsage: TokenUsageData): TokenUsageData {
+  return {
+    ...baseUsage,
+    thinkingTokens: usage.thinkingTokens,
+    thinkingBudgetTokens: usage.thinkingBudgetTokens,
+    cachedTokens: usage.cachedTokens,
+    cacheCreationTokens: usage.cacheCreationTokens,
+    cacheReadTokens: usage.cacheReadTokens,
+  };
+}
+
+/**
+ * Extract Google-specific token usage
+ */
+function extractGoogleTokens(usage: any, baseUsage: TokenUsageData): TokenUsageData {
+  return {
+    ...baseUsage,
+    cachedTokens: usage.cachedTokens,
+  };
+}
+
+/**
+ * Infer provider from model name
+ */
+function inferProviderFromModel(model: string): string {
+  const modelLower = model.toLowerCase();
+  
+  if (modelLower.includes('gpt') || modelLower.includes('o1') || modelLower.includes('openai')) {
+    return 'openai';
+  }
+  
+  if (modelLower.includes('claude') || modelLower.includes('anthropic')) {
+    return 'anthropic';
+  }
+  
+  if (modelLower.includes('gemini') || modelLower.includes('google')) {
+    return 'google';
+  }
+  
+  return 'unknown';
+}
+
+/**
+ * Save token usage data to database
+ */
+export async function saveTokenUsage(usageData: TokenUsageData): Promise<void> {
+  try {
+    await saveTokenUsageQuery(usageData);
+  } catch (error) {
+    console.error('Failed to save token usage:', error);
+    throw error;
+  }
+}
+
+/**
+ * Record token usage from AI SDK telemetry data
+ */
+export async function recordTokenUsage(
+  telemetryData: any,
+  chatId: string,
+  userId: string,
+  spaceId?: string,
+  model?: string,
+  provider?: string
+): Promise<void> {
+  const usageData = extractTokenUsage(telemetryData, chatId, userId, spaceId, model, provider);
+  
+  if (usageData) {
+    await saveTokenUsage(usageData);
+  }
+}


### PR DESCRIPTION
Implement comprehensive token usage tracking using AI SDK's built-in experimental_telemetry feature to capture detailed usage data from all providers.

Key requirements:
1. Create comprehensive token_usage table supporting all token types (standard, reasoning, thinking, cached)
2. Enable telemetry in chat API endpoint with proper usage data extraction
3. Support provider-specific token types (OpenAI reasoning tokens, Anthropic extended thinking)
4. Store raw usage data in JSONB for future analysis
5. Handle type safety with optional selectedSpace
6. Create provider-aware usage extraction utility
7. Add database migration
8. Add token usage recording utility

Database schema should include:
- Standard tokens: prompt_tokens, completion_tokens, total_tokens
- Reasoning tokens (OpenAI): reasoning_tokens
- Thinking tokens (Anthropic): thinking_tokens, thinking_budget_tokens
- Caching tokens: cached_tokens, cache_creation_tokens, cache_read_tokens
- Raw usage data in JSONB
- Provider metadata
- User/space correlation

Implementation should:
- Modify conversational-ui/app/(chat)/api/chat/route.ts to add telemetry
- Add token_usage table to conversational-ui/lib/db/schema.ts
- Create token usage queries in conversational-ui/lib/db/queries.ts
- Create utility for provider-aware usage extraction
- Add database migration
- Ensure type safety with session.user.selectedSpace?.id handling