### PR TITLE
Implement per-message token usage tracking (raw usage data only)

### DIFF
--- a/conversational-ui/lib/db/migrations/0014_token_usage_table.sql
+++ b/conversational-ui/lib/db/migrations/0014_token_usage_table.sql
@@ -1,0 +1,22 @@
+CREATE TABLE IF NOT EXISTS "token_usage" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" text NOT NULL,
+	"space_id" text,
+	"message_id" uuid NOT NULL,
+	"chat_id" text,
+	"provider" text NOT NULL,
+	"model" text NOT NULL,
+	"operation_type" text NOT NULL,
+	"operation_id" text,
+	"raw_usage_data" jsonb NOT NULL,
+	"provider_metadata" jsonb,
+	"finish_reason" text,
+	"request_id" text,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "token_usage" ADD CONSTRAINT "token_usage_message_id_Message_v2_id_fk" FOREIGN KEY ("message_id") REFERENCES "Message_v2"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;

--- a/conversational-ui/lib/db/migrations/meta/0014_snapshot.json
+++ b/conversational-ui/lib/db/migrations/meta/0014_snapshot.json
@@ -1,0 +1,201 @@
+{
+  "id": "0014_token_usage_table",
+  "prevId": "0013_gifted_silver_centurion",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "Chat": {
+      "name": "Chat",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "spaceId": {
+          "name": "spaceId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Chat_userId_User_id_fk": {
+          "name": "Chat_userId_User_id_fk",
+          "tableFrom": "Chat",
+          "tableTo": "User",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "Chat_spaceId_Space_id_fk": {
+          "name": "Chat_spaceId_Space_id_fk",
+          "tableFrom": "Chat",
+          "tableTo": "Space",
+          "columnsFrom": [
+            "spaceId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "token_usage": {
+      "name": "token_usage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_type": {
+          "name": "operation_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_usage_data": {
+          "name": "raw_usage_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_metadata": {
+          "name": "provider_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finish_reason": {
+          "name": "finish_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "token_usage_message_id_Message_v2_id_fk": {
+          "name": "token_usage_message_id_Message_v2_id_fk",
+          "tableFrom": "token_usage",
+          "tableTo": "Message_v2",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/conversational-ui/lib/db/migrations/meta/_journal.json
+++ b/conversational-ui/lib/db/migrations/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1750351007882,
       "tag": "0013_gifted_silver_centurion",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1750351007883,
+      "tag": "0014_token_usage_table",
+      "breakpoints": true
     }
   ]
 }

--- a/conversational-ui/lib/db/queries.ts
+++ b/conversational-ui/lib/db/queries.ts
@@ -18,6 +18,8 @@ import {
   space,
   spaceToUser,
   stream,
+  tokenUsage,
+  type TokenUsage,
 } from './schema';
 import { ArtifactKind } from '@/components/artifact';
 
@@ -793,6 +795,80 @@ export async function updateUserProfile(userId: string, updates: { name?: string
     return await db.update(user).set(updates).where(eq(user.id, userId));
   } catch (error) {
     console.error('Failed to update user profile');
+    throw error;
+  }
+}
+
+export async function saveTokenUsage({
+  userId,
+  spaceId,
+  messageId,
+  chatId,
+  provider,
+  model,
+  operationType,
+  operationId,
+  rawUsageData,
+  providerMetadata,
+  finishReason,
+  requestId,
+}: {
+  userId: string;
+  spaceId?: string | null;
+  messageId: string;
+  chatId?: string | null;
+  provider: string;
+  model: string;
+  operationType: string;
+  operationId?: string | null;
+  rawUsageData: any;
+  providerMetadata?: any;
+  finishReason?: string | null;
+  requestId?: string | null;
+}) {
+  try {
+    return await db.insert(tokenUsage).values({
+      userId,
+      spaceId,
+      messageId,
+      chatId,
+      provider,
+      model,
+      operationType,
+      operationId,
+      rawUsageData,
+      providerMetadata,
+      finishReason,
+      requestId,
+    });
+  } catch (error) {
+    console.error('Failed to save token usage in database');
+    throw error;
+  }
+}
+
+export async function getTokenUsageByMessageId({ messageId }: { messageId: string }) {
+  try {
+    return await db
+      .select()
+      .from(tokenUsage)
+      .where(eq(tokenUsage.messageId, messageId))
+      .orderBy(desc(tokenUsage.createdAt));
+  } catch (error) {
+    console.error('Failed to get token usage by message id from database');
+    throw error;
+  }
+}
+
+export async function getTokenUsageByChatId({ chatId }: { chatId: string }) {
+  try {
+    return await db
+      .select()
+      .from(tokenUsage)
+      .where(eq(tokenUsage.chatId, chatId))
+      .orderBy(desc(tokenUsage.createdAt));
+  } catch (error) {
+    console.error('Failed to get token usage by chat id from database');
     throw error;
   }
 }

--- a/conversational-ui/lib/db/schema.ts
+++ b/conversational-ui/lib/db/schema.ts
@@ -9,6 +9,7 @@ import {
   primaryKey,
   foreignKey,
   boolean,
+  jsonb,
 } from 'drizzle-orm/pg-core';
 
 export const space = pgTable('Space', {
@@ -205,3 +206,22 @@ export const stream = pgTable(
 );
 
 export type Stream = InferSelectModel<typeof stream>;
+
+export const tokenUsage = pgTable('token_usage', {
+  id: uuid('id').primaryKey().notNull().defaultRandom(),
+  userId: text('user_id').notNull(),
+  spaceId: text('space_id'),
+  messageId: uuid('message_id').notNull().references(() => message.id),
+  chatId: text('chat_id'),
+  provider: text('provider').notNull(),
+  model: text('model').notNull(),
+  operationType: text('operation_type').notNull(),
+  operationId: text('operation_id'),
+  rawUsageData: jsonb('raw_usage_data').notNull(),
+  providerMetadata: jsonb('provider_metadata'),
+  finishReason: text('finish_reason'),
+  requestId: text('request_id'),
+  createdAt: timestamp('created_at').notNull().defaultNow(),
+});
+
+export type TokenUsage = InferSelectModel<typeof tokenUsage>;


### PR DESCRIPTION
Implement per-message token usage tracking for chat interactions in the Conversational UI. Store only the raw usage data and provider metadata from the AI SDK (no explicit mapping of reasoning, thinking, or caching tokens). Usage must be associated with each message (not just chat). 

Requirements:
- Add a `token_usage` table with the following fields:
  - id (UUID, PK)
  - user_id (string, not null)
  - space_id (string, nullable)
  - message_id (UUID, not null, references Message table)
  - chat_id (string, optional)
  - provider (string, not null)
  - model (string, not null)
  - operation_type (string, not null)
  - operation_id (string)
  - raw_usage_data (JSONB, not null)
  - provider_metadata (JSONB, nullable)
  - finish_reason (string, nullable)
  - request_id (string, nullable)
  - created_at (timestamp, default now)
- Update the chat API endpoint to record token usage per message using the AI SDK's `onFinish` callback.
- Add a utility to insert token usage records.
- Update queries/types as needed.
- Migration for the new table.
- Type safety: No TypeScript errors with optional selectedSpace.
- Test: Each message generates a complete token usage record.

Do not implement cost calculation. Focus only on raw usage data and per-message association.