### PR TITLE
Add Token Tracking to Conversational UI Chat

### DIFF
--- a/conversational-ui/lib/db/migrations/0014_add_token_usage.sql
+++ b/conversational-ui/lib/db/migrations/0014_add_token_usage.sql
@@ -1,0 +1,27 @@
+CREATE TABLE IF NOT EXISTS "TokenUsage" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"messageId" uuid NOT NULL,
+	"chatId" uuid NOT NULL,
+	"provider" varchar(50) NOT NULL,
+	"model" varchar(100) NOT NULL,
+	"promptTokens" integer NOT NULL,
+	"completionTokens" integer NOT NULL,
+	"totalTokens" integer NOT NULL,
+	"inputCost" integer,
+	"outputCost" integer,
+	"totalCost" integer,
+	"providerMetadata" json,
+	"createdAt" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "TokenUsage" ADD CONSTRAINT "TokenUsage_messageId_Message_v2_id_fk" FOREIGN KEY ("messageId") REFERENCES "public"."Message_v2"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "TokenUsage" ADD CONSTRAINT "TokenUsage_chatId_Chat_id_fk" FOREIGN KEY ("chatId") REFERENCES "public"."Chat"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;

--- a/conversational-ui/lib/db/migrations/meta/0014_snapshot.json
+++ b/conversational-ui/lib/db/migrations/meta/0014_snapshot.json
@@ -1,0 +1,922 @@
+{
+  "id": "c3d89905-55e0-4d66-bbae-87eb9cfabfcb",
+  "prevId": "b2c89804-44d9-4c55-aaad-76da8bfadeba",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.Chat": {
+      "name": "Chat",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "spaceId": {
+          "name": "spaceId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Chat_userId_User_id_fk": {
+          "name": "Chat_userId_User_id_fk",
+          "tableFrom": "Chat",
+          "tableTo": "User",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "Chat_spaceId_Space_id_fk": {
+          "name": "Chat_spaceId_Space_id_fk",
+          "tableFrom": "Chat",
+          "tableTo": "Space",
+          "columnsFrom": [
+            "spaceId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Document": {
+      "name": "Document",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'text'"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Document_userId_User_id_fk": {
+          "name": "Document_userId_User_id_fk",
+          "tableFrom": "Document",
+          "tableTo": "User",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "Document_id_createdAt_pk": {
+          "name": "Document_id_createdAt_pk",
+          "columns": [
+            "id",
+            "createdAt"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Message_v2": {
+      "name": "Message_v2",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chatId": {
+          "name": "chatId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parts": {
+          "name": "parts",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Message_v2_chatId_Chat_id_fk": {
+          "name": "Message_v2_chatId_Chat_id_fk",
+          "tableFrom": "Message_v2",
+          "tableTo": "Chat",
+          "columnsFrom": [
+            "chatId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Message": {
+      "name": "Message",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chatId": {
+          "name": "chatId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "experimental_attachments": {
+          "name": "experimental_attachments",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Message_chatId_Chat_id_fk": {
+          "name": "Message_chatId_Chat_id_fk",
+          "tableFrom": "Message",
+          "tableTo": "Chat",
+          "columnsFrom": [
+            "chatId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Space": {
+      "name": "Space",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "knowledgeBaseId": {
+          "name": "knowledgeBaseId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processId": {
+          "name": "processId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connectedRepoUrl": {
+          "name": "connectedRepoUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "isDefault": {
+          "name": "isDefault",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.SpaceToUser": {
+      "name": "SpaceToUser",
+      "schema": "",
+      "columns": {
+        "spaceId": {
+          "name": "spaceId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "SpaceToUser_spaceId_Space_id_fk": {
+          "name": "SpaceToUser_spaceId_Space_id_fk",
+          "tableFrom": "SpaceToUser",
+          "tableTo": "Space",
+          "columnsFrom": [
+            "spaceId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "SpaceToUser_userId_User_id_fk": {
+          "name": "SpaceToUser_userId_User_id_fk",
+          "tableFrom": "SpaceToUser",
+          "tableTo": "User",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "SpaceToUser_spaceId_userId_pk": {
+          "name": "SpaceToUser_spaceId_userId_pk",
+          "columns": [
+            "spaceId",
+            "userId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Stream": {
+      "name": "Stream",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chatId": {
+          "name": "chatId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Stream_chatId_Chat_id_fk": {
+          "name": "Stream_chatId_Chat_id_fk",
+          "tableFrom": "Stream",
+          "tableTo": "Chat",
+          "columnsFrom": [
+            "chatId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "Stream_id_pk": {
+          "name": "Stream_id_pk",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Suggestion": {
+      "name": "Suggestion",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "documentId": {
+          "name": "documentId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "documentCreatedAt": {
+          "name": "documentCreatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "originalText": {
+          "name": "originalText",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggestedText": {
+          "name": "suggestedText",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isResolved": {
+          "name": "isResolved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Suggestion_userId_User_id_fk": {
+          "name": "Suggestion_userId_User_id_fk",
+          "tableFrom": "Suggestion",
+          "tableTo": "User",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "Suggestion_documentId_documentCreatedAt_Document_id_createdAt_fk": {
+          "name": "Suggestion_documentId_documentCreatedAt_Document_id_createdAt_fk",
+          "tableFrom": "Suggestion",
+          "tableTo": "Document",
+          "columnsFrom": [
+            "documentId",
+            "documentCreatedAt"
+          ],
+          "columnsTo": [
+            "id",
+            "createdAt"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "Suggestion_id_pk": {
+          "name": "Suggestion_id_pk",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.TokenUsage": {
+      "name": "TokenUsage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "messageId": {
+          "name": "messageId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chatId": {
+          "name": "chatId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "promptTokens": {
+          "name": "promptTokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completionTokens": {
+          "name": "completionTokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "totalTokens": {
+          "name": "totalTokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inputCost": {
+          "name": "inputCost",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outputCost": {
+          "name": "outputCost",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "totalCost": {
+          "name": "totalCost",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "providerMetadata": {
+          "name": "providerMetadata",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "TokenUsage_messageId_Message_v2_id_fk": {
+          "name": "TokenUsage_messageId_Message_v2_id_fk",
+          "tableFrom": "TokenUsage",
+          "tableTo": "Message_v2",
+          "columnsFrom": [
+            "messageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "TokenUsage_chatId_Chat_id_fk": {
+          "name": "TokenUsage_chatId_Chat_id_fk",
+          "tableFrom": "TokenUsage",
+          "tableTo": "Chat",
+          "columnsFrom": [
+            "chatId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.User": {
+      "name": "User",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password": {
+          "name": "password",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selectedSpaceId": {
+          "name": "selectedSpaceId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emailVerificationToken": {
+          "name": "emailVerificationToken",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hasCompletedOnboarding": {
+          "name": "hasCompletedOnboarding",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "profileNotes": {
+          "name": "profileNotes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "User_selectedSpaceId_Space_id_fk": {
+          "name": "User_selectedSpaceId_Space_id_fk",
+          "tableFrom": "User",
+          "tableTo": "Space",
+          "columnsFrom": [
+            "selectedSpaceId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Vote_v2": {
+      "name": "Vote_v2",
+      "schema": "",
+      "columns": {
+        "chatId": {
+          "name": "chatId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "messageId": {
+          "name": "messageId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isUpvoted": {
+          "name": "isUpvoted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Vote_v2_chatId_Chat_id_fk": {
+          "name": "Vote_v2_chatId_Chat_id_fk",
+          "tableFrom": "Vote_v2",
+          "tableTo": "Chat",
+          "columnsFrom": [
+            "chatId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "Vote_v2_messageId_Message_v2_id_fk": {
+          "name": "Vote_v2_messageId_Message_v2_id_fk",
+          "tableFrom": "Vote_v2",
+          "tableTo": "Message_v2",
+          "columnsFrom": [
+            "messageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "Vote_v2_chatId_messageId_pk": {
+          "name": "Vote_v2_chatId_messageId_pk",
+          "columns": [
+            "chatId",
+            "messageId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Vote": {
+      "name": "Vote",
+      "schema": "",
+      "columns": {
+        "chatId": {
+          "name": "chatId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "messageId": {
+          "name": "messageId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isUpvoted": {
+          "name": "isUpvoted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Vote_chatId_Chat_id_fk": {
+          "name": "Vote_chatId_Chat_id_fk",
+          "tableFrom": "Vote",
+          "tableTo": "Chat",
+          "columnsFrom": [
+            "chatId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "Vote_messageId_Message_id_fk": {
+          "name": "Vote_messageId_Message_id_fk",
+          "tableFrom": "Vote",
+          "tableTo": "Message",
+          "columnsFrom": [
+            "messageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "Vote_chatId_messageId_pk": {
+          "name": "Vote_chatId_messageId_pk",
+          "columns": [
+            "chatId",
+            "messageId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/conversational-ui/lib/db/migrations/meta/_journal.json
+++ b/conversational-ui/lib/db/migrations/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1750351007882,
       "tag": "0013_gifted_silver_centurion",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1750351008000,
+      "tag": "0014_add_token_usage",
+      "breakpoints": true
     }
   ]
 }

--- a/conversational-ui/lib/db/schema.ts
+++ b/conversational-ui/lib/db/schema.ts
@@ -9,6 +9,7 @@ import {
   primaryKey,
   foreignKey,
   boolean,
+  integer,
 } from 'drizzle-orm/pg-core';
 
 export const space = pgTable('Space', {
@@ -205,3 +206,25 @@ export const stream = pgTable(
 );
 
 export type Stream = InferSelectModel<typeof stream>;
+
+export const tokenUsage = pgTable('TokenUsage', {
+  id: uuid('id').primaryKey().notNull().defaultRandom(),
+  messageId: uuid('messageId')
+    .notNull()
+    .references(() => message.id),
+  chatId: uuid('chatId')
+    .notNull()
+    .references(() => chat.id),
+  provider: varchar('provider', { length: 50 }).notNull(),
+  model: varchar('model', { length: 100 }).notNull(),
+  promptTokens: integer('promptTokens').notNull(),
+  completionTokens: integer('completionTokens').notNull(),
+  totalTokens: integer('totalTokens').notNull(),
+  inputCost: integer('inputCost'), // Cost in microdollars (1/1,000,000 of a dollar)
+  outputCost: integer('outputCost'), // Cost in microdollars
+  totalCost: integer('totalCost'), // Cost in microdollars
+  providerMetadata: json('providerMetadata'), // Store additional provider-specific data
+  createdAt: timestamp('createdAt').notNull().defaultNow(),
+});
+
+export type TokenUsage = InferSelectModel<typeof tokenUsage>;

--- a/conversational-ui/lib/utils/token-usage.ts
+++ b/conversational-ui/lib/utils/token-usage.ts
@@ -1,0 +1,233 @@
+import 'server-only';
+import { drizzle } from 'drizzle-orm/postgres-js';
+import postgres from 'postgres';
+import { tokenUsage } from '../db/schema';
+import type { TokenUsage } from '../db/schema';
+
+// AI SDK telemetry types
+export interface TelemetryUsage {
+  promptTokens: number;
+  completionTokens: number;
+  totalTokens: number;
+}
+
+export interface TelemetryData {
+  usage?: TelemetryUsage;
+  experimental_providerMetadata?: {
+    anthropic?: {
+      cacheCreationInputTokens?: number;
+      cacheReadInputTokens?: number;
+      [key: string]: any;
+    };
+    openai?: {
+      reasoning_tokens?: number;
+      [key: string]: any;
+    };
+    google?: {
+      [key: string]: any;
+    };
+    [key: string]: any;
+  };
+}
+
+// Cost calculation utilities (in microdollars)
+const MODEL_COSTS = {
+  // OpenAI GPT-4 models (per 1K tokens)
+  'gpt-4o': { input: 2500, output: 10000 }, // $0.0025 input, $0.01 output
+  'gpt-4o-mini': { input: 150, output: 600 }, // $0.00015 input, $0.0006 output
+  'gpt-4-turbo': { input: 10000, output: 30000 }, // $0.01 input, $0.03 output
+  'gpt-4': { input: 30000, output: 60000 }, // $0.03 input, $0.06 output
+  'gpt-3.5-turbo': { input: 500, output: 1500 }, // $0.0005 input, $0.0015 output
+  
+  // Anthropic Claude models (per 1K tokens)
+  'claude-3-5-sonnet-20241022': { input: 3000, output: 15000 }, // $0.003 input, $0.015 output
+  'claude-3-5-haiku-20241022': { input: 1000, output: 5000 }, // $0.001 input, $0.005 output
+  'claude-3-opus-20240229': { input: 15000, output: 75000 }, // $0.015 input, $0.075 output
+  'claude-3-sonnet-20240229': { input: 3000, output: 15000 }, // $0.003 input, $0.015 output
+  'claude-3-haiku-20240307': { input: 250, output: 1250 }, // $0.00025 input, $0.00125 output
+  
+  // Google Gemini models (per 1K tokens)
+  'gemini-1.5-pro': { input: 2500, output: 10000 }, // $0.0025 input, $0.01 output
+  'gemini-1.5-flash': { input: 75, output: 300 }, // $0.000075 input, $0.0003 output
+} as const;
+
+function extractProviderAndModel(fullModelName: string): { provider: string; model: string } {
+  // Handle provider-prefixed models (e.g., "openai:gpt-4o")
+  if (fullModelName.includes(':')) {
+    const [provider, model] = fullModelName.split(':', 2);
+    return { provider, model };
+  }
+  
+  // Infer provider from model name patterns
+  if (fullModelName.startsWith('gpt-')) {
+    return { provider: 'openai', model: fullModelName };
+  }
+  
+  if (fullModelName.startsWith('claude-')) {
+    return { provider: 'anthropic', model: fullModelName };
+  }
+  
+  if (fullModelName.startsWith('gemini-')) {
+    return { provider: 'google', model: fullModelName };
+  }
+  
+  // Default fallback
+  return { provider: 'unknown', model: fullModelName };
+}
+
+function calculateCost(model: string, promptTokens: number, completionTokens: number): {
+  inputCost: number;
+  outputCost: number;
+  totalCost: number;
+} {
+  const costs = MODEL_COSTS[model as keyof typeof MODEL_COSTS];
+  
+  if (!costs) {
+    return { inputCost: 0, outputCost: 0, totalCost: 0 };
+  }
+  
+  // Calculate costs in microdollars
+  const inputCost = Math.round((promptTokens / 1000) * costs.input);
+  const outputCost = Math.round((completionTokens / 1000) * costs.output);
+  const totalCost = inputCost + outputCost;
+  
+  return { inputCost, outputCost, totalCost };
+}
+
+export interface TokenUsageRecord {
+  messageId: string;
+  chatId: string;
+  provider: string;
+  model: string;
+  promptTokens: number;
+  completionTokens: number;
+  totalTokens: number;
+  inputCost?: number;
+  outputCost?: number;
+  totalCost?: number;
+  providerMetadata?: any;
+}
+
+export function createTokenUsageRecord(
+  messageId: string,
+  chatId: string,
+  modelName: string,
+  telemetryData: TelemetryData
+): TokenUsageRecord | null {
+  // Early return if no usage data
+  if (!telemetryData.usage) {
+    console.warn('No usage data found in telemetry');
+    return null;
+  }
+  
+  const { usage, experimental_providerMetadata } = telemetryData;
+  const { provider, model } = extractProviderAndModel(modelName);
+  
+  // Validate required fields
+  if (!usage.promptTokens || !usage.completionTokens || !usage.totalTokens) {
+    console.warn('Incomplete usage data in telemetry');
+    return null;
+  }
+  
+  // Calculate costs
+  const { inputCost, outputCost, totalCost } = calculateCost(
+    model,
+    usage.promptTokens,
+    usage.completionTokens
+  );
+  
+  return {
+    messageId,
+    chatId,
+    provider,
+    model,
+    promptTokens: usage.promptTokens,
+    completionTokens: usage.completionTokens,
+    totalTokens: usage.totalTokens,
+    inputCost: inputCost > 0 ? inputCost : undefined,
+    outputCost: outputCost > 0 ? outputCost : undefined,
+    totalCost: totalCost > 0 ? totalCost : undefined,
+    providerMetadata: experimental_providerMetadata || undefined,
+  };
+}
+
+// Database connection
+const client = postgres(process.env.POSTGRES_URL!);
+const db = drizzle(client);
+
+export async function saveTokenUsage(record: TokenUsageRecord): Promise<void> {
+  try {
+    await db.insert(tokenUsage).values({
+      messageId: record.messageId,
+      chatId: record.chatId,
+      provider: record.provider,
+      model: record.model,
+      promptTokens: record.promptTokens,
+      completionTokens: record.completionTokens,
+      totalTokens: record.totalTokens,
+      inputCost: record.inputCost,
+      outputCost: record.outputCost,
+      totalCost: record.totalCost,
+      providerMetadata: record.providerMetadata,
+    });
+    
+    console.log(`✅ Token usage recorded for message ${record.messageId}: ${record.totalTokens} tokens`);
+  } catch (error) {
+    console.error('❌ Failed to save token usage:', error);
+    throw error;
+  }
+}
+
+export async function recordTokenUsage(
+  messageId: string,
+  chatId: string,
+  modelName: string,
+  telemetryData: TelemetryData
+): Promise<void> {
+  const record = createTokenUsageRecord(messageId, chatId, modelName, telemetryData);
+  
+  if (!record) {
+    console.warn('No token usage record created, skipping save');
+    return;
+  }
+  
+  await saveTokenUsage(record);
+}
+
+// Utility to format costs for display
+export function formatCost(microdollars: number): string {
+  const dollars = microdollars / 1_000_000;
+  return `$${dollars.toFixed(6)}`;
+}
+
+// Type-safe telemetry data handler
+export function handleTelemetryData(data: unknown): TelemetryData | null {
+  if (!data || typeof data !== 'object') {
+    return null;
+  }
+  
+  const obj = data as Record<string, any>;
+  
+  // Validate usage object structure
+  if (!obj.usage || typeof obj.usage !== 'object') {
+    return null;
+  }
+  
+  const usage = obj.usage as Record<string, any>;
+  if (
+    typeof usage.promptTokens !== 'number' ||
+    typeof usage.completionTokens !== 'number' ||
+    typeof usage.totalTokens !== 'number'
+  ) {
+    return null;
+  }
+  
+  return {
+    usage: {
+      promptTokens: usage.promptTokens,
+      completionTokens: usage.completionTokens,
+      totalTokens: usage.totalTokens,
+    },
+    experimental_providerMetadata: obj.experimental_providerMetadata || undefined,
+  };
+}


### PR DESCRIPTION
Implement comprehensive token usage tracking using AI SDK's built-in `experimental_telemetry` feature. Store only the raw usage data and provider metadata, and associate usage with each message (not just chat).

**Key steps:**
- Add `token_usage` table (per-message, provider-agnostic) to the DB schema
- Enable telemetry in chat API endpoint (per-message)
- Create token usage recording utility
- Add token usage queries
- Ensure type safety and null handling for optional fields
- Add migration for the new table
- Test: Each message generates a complete token usage record
- Make sure `pnpm build` passes before submitting the PR

**Files to modify:**
- conversational-ui/lib/db/schema.ts
- conversational-ui/app/(chat)/api/chat/route.ts
- conversational-ui/lib/db/queries.ts
- conversational-ui/lib/utils/token-usage.ts (new)
- conversational-ui/lib/db/migrations/ (new migration)
