### PR TITLE
Add Token Tracking to Conversational UI Chat

### DIFF
--- a/conversational-ui/lib/db/migrations/0014_add_token_usage_table.sql
+++ b/conversational-ui/lib/db/migrations/0014_add_token_usage_table.sql
@@ -1,0 +1,21 @@
+CREATE TABLE "TokenUsage" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"userId" uuid NOT NULL,
+	"spaceId" uuid NOT NULL,
+	"messageId" uuid NOT NULL,
+	"chatId" uuid NOT NULL,
+	"provider" varchar(50) NOT NULL,
+	"model" varchar(100) NOT NULL,
+	"operationType" varchar(50) NOT NULL,
+	"operationId" varchar(255),
+	"rawUsageData" jsonb NOT NULL,
+	"providerMetadata" jsonb,
+	"finishReason" varchar(50),
+	"requestId" varchar(255),
+	"createdAt" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "TokenUsage" ADD CONSTRAINT "TokenUsage_userId_User_id_fk" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "TokenUsage" ADD CONSTRAINT "TokenUsage_spaceId_Space_id_fk" FOREIGN KEY ("spaceId") REFERENCES "Space"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "TokenUsage" ADD CONSTRAINT "TokenUsage_messageId_Message_v2_id_fk" FOREIGN KEY ("messageId") REFERENCES "Message_v2"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "TokenUsage" ADD CONSTRAINT "TokenUsage_chatId_Chat_id_fk" FOREIGN KEY ("chatId") REFERENCES "Chat"("id") ON DELETE no action ON UPDATE no action;

--- a/conversational-ui/lib/db/schema.ts
+++ b/conversational-ui/lib/db/schema.ts
@@ -9,6 +9,7 @@ import {
   primaryKey,
   foreignKey,
   boolean,
+  jsonb,
 } from 'drizzle-orm/pg-core';
 
 export const space = pgTable('Space', {
@@ -205,3 +206,30 @@ export const stream = pgTable(
 );
 
 export type Stream = InferSelectModel<typeof stream>;
+
+export const tokenUsage = pgTable('TokenUsage', {
+  id: uuid('id').primaryKey().notNull().defaultRandom(),
+  userId: uuid('userId')
+    .notNull()
+    .references(() => user.id),
+  spaceId: uuid('spaceId')
+    .notNull()
+    .references(() => space.id),
+  messageId: uuid('messageId')
+    .notNull()
+    .references(() => message.id),
+  chatId: uuid('chatId')
+    .notNull()
+    .references(() => chat.id),
+  provider: varchar('provider', { length: 50 }).notNull(),
+  model: varchar('model', { length: 100 }).notNull(),
+  operationType: varchar('operationType', { length: 50 }).notNull(),
+  operationId: varchar('operationId', { length: 255 }),
+  rawUsageData: jsonb('rawUsageData').notNull(),
+  providerMetadata: jsonb('providerMetadata'),
+  finishReason: varchar('finishReason', { length: 50 }),
+  requestId: varchar('requestId', { length: 255 }),
+  createdAt: timestamp('createdAt').notNull().defaultNow(),
+});
+
+export type TokenUsage = InferSelectModel<typeof tokenUsage>;

--- a/conversational-ui/lib/utils/token-usage.ts
+++ b/conversational-ui/lib/utils/token-usage.ts
@@ -1,0 +1,95 @@
+import 'server-only';
+
+import { tokenUsage } from '@/lib/db/schema';
+import { db } from '@/lib/db';
+
+export interface RecordTokenUsageParams {
+  userId: string;
+  spaceId: string;
+  messageId: string;
+  chatId: string;
+  provider: string;
+  model: string;
+  operationType: string;
+  operationId?: string;
+  rawUsageData: Record<string, any>;
+  providerMetadata?: Record<string, any>;
+  finishReason?: string;
+  requestId?: string;
+}
+
+export interface TokenUsageFromTelemetry {
+  provider: string;
+  model: string;
+  operationType: string;
+  operationId?: string;
+  rawUsageData: Record<string, any>;
+  providerMetadata?: Record<string, any>;
+  finishReason?: string;
+  requestId?: string;
+}
+
+/**
+ * Records token usage data to the database
+ * Stores raw usage data and provider metadata for comprehensive tracking
+ */
+export async function recordTokenUsage(params: RecordTokenUsageParams): Promise<void> {
+  try {
+    await db.insert(tokenUsage).values({
+      userId: params.userId,
+      spaceId: params.spaceId,
+      messageId: params.messageId,
+      chatId: params.chatId,
+      provider: params.provider,
+      model: params.model,
+      operationType: params.operationType,
+      operationId: params.operationId,
+      rawUsageData: params.rawUsageData,
+      providerMetadata: params.providerMetadata,
+      finishReason: params.finishReason,
+      requestId: params.requestId,
+      createdAt: new Date(),
+    });
+  } catch (error) {
+    console.error('Failed to record token usage:', error);
+    // Don't throw to avoid breaking the chat flow
+  }
+}
+
+/**
+ * Extracts token usage data from AI SDK telemetry data
+ */
+export function extractTokenUsageFromTelemetry(telemetryData: any): TokenUsageFromTelemetry | null {
+  try {
+    if (!telemetryData || !telemetryData.usage) {
+      console.log('No usage data found in telemetry:', telemetryData);
+      return null;
+    }
+
+    // Extract provider information from model metadata or default
+    const provider = telemetryData.model?.provider || telemetryData.provider || 'unknown';
+    const modelName = telemetryData.model?.modelId || telemetryData.model || 'unknown';
+    
+    return {
+      provider,
+      model: modelName,
+      operationType: telemetryData.operationType || 'generate',
+      operationId: telemetryData.operationId,
+      rawUsageData: {
+        usage: telemetryData.usage,
+        timestamp: telemetryData.timestamp || new Date().toISOString(),
+        durationMs: telemetryData.durationMs,
+      },
+      providerMetadata: {
+        model: telemetryData.model,
+        settings: telemetryData.settings,
+        response: telemetryData.response,
+      },
+      finishReason: telemetryData.response?.finishReason,
+      requestId: telemetryData.response?.id || telemetryData.requestId,
+    };
+  } catch (error) {
+    console.error('Failed to extract token usage from telemetry:', error);
+    return null;
+  }
+}


### PR DESCRIPTION
Implement comprehensive token usage tracking using AI SDK's built-in experimental_telemetry feature. Store only the raw usage data and provider metadata, and associate usage with each message (not just chat).

Key Requirements:
1. Create token_usage table with per-message, provider-agnostic schema:
   - id, user_id, space_id, message_id, chat_id, provider, model, operation_type, operation_id
   - raw_usage_data (JSONB), provider_metadata (JSONB), finish_reason, request_id, created_at

2. Enable telemetry in chat API endpoint with per-message tracking:
   - Use experimental_telemetry in streamText
   - Record usage in onFinish callback
   - Associate with specific message ID

3. Create token usage recording utility:
   - recordTokenUsage function
   - Proper database insertion
   - Type safety with optional selectedSpace

4. Database migration for new table

Files to modify:
- conversational-ui/lib/db/schema.ts - Add token_usage table
- conversational-ui/app/(chat)/api/chat/route.ts - Add telemetry and per-message recording
- conversational-ui/lib/db/queries.ts - Add token usage queries
- conversational-ui/lib/utils/token-usage.ts - New usage recording utility
- conversational-ui/lib/db/migrations/ - New migration file

Ensure pnpm build:only passes before submitting PR. Priority: High - provides essential visibility into token consumption patterns.