### PR TITLE
Add Minimal Token Usage Tracking per Message

### DIFF
--- a/conversational-ui/lib/db/migrations/0014_material_iron_patriot.sql
+++ b/conversational-ui/lib/db/migrations/0014_material_iron_patriot.sql
@@ -1,0 +1,9 @@
+CREATE TABLE "TokenUsage" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"message_id" uuid NOT NULL,
+	"provider" varchar(50) NOT NULL,
+	"model" varchar(100) NOT NULL,
+	"raw_usage_data" jsonb NOT NULL,
+	"provider_metadata" jsonb,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);

--- a/conversational-ui/lib/db/migrations/meta/0014_snapshot.json
+++ b/conversational-ui/lib/db/migrations/meta/0014_snapshot.json
@@ -1,0 +1,859 @@
+{
+  "id": "17789306-2caa-4a1c-95cd-7ad599538442",
+  "prevId": "b2c89804-44d9-4c55-aaad-76da8bfadeba",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.Chat": {
+      "name": "Chat",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "spaceId": {
+          "name": "spaceId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Chat_userId_User_id_fk": {
+          "name": "Chat_userId_User_id_fk",
+          "tableFrom": "Chat",
+          "tableTo": "User",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "Chat_spaceId_Space_id_fk": {
+          "name": "Chat_spaceId_Space_id_fk",
+          "tableFrom": "Chat",
+          "tableTo": "Space",
+          "columnsFrom": [
+            "spaceId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Document": {
+      "name": "Document",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'text'"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Document_userId_User_id_fk": {
+          "name": "Document_userId_User_id_fk",
+          "tableFrom": "Document",
+          "tableTo": "User",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "Document_id_createdAt_pk": {
+          "name": "Document_id_createdAt_pk",
+          "columns": [
+            "id",
+            "createdAt"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Message_v2": {
+      "name": "Message_v2",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chatId": {
+          "name": "chatId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parts": {
+          "name": "parts",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Message_v2_chatId_Chat_id_fk": {
+          "name": "Message_v2_chatId_Chat_id_fk",
+          "tableFrom": "Message_v2",
+          "tableTo": "Chat",
+          "columnsFrom": [
+            "chatId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Message": {
+      "name": "Message",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chatId": {
+          "name": "chatId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "experimental_attachments": {
+          "name": "experimental_attachments",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Message_chatId_Chat_id_fk": {
+          "name": "Message_chatId_Chat_id_fk",
+          "tableFrom": "Message",
+          "tableTo": "Chat",
+          "columnsFrom": [
+            "chatId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Space": {
+      "name": "Space",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "knowledgeBaseId": {
+          "name": "knowledgeBaseId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processId": {
+          "name": "processId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connectedRepoUrl": {
+          "name": "connectedRepoUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "isDefault": {
+          "name": "isDefault",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.SpaceToUser": {
+      "name": "SpaceToUser",
+      "schema": "",
+      "columns": {
+        "spaceId": {
+          "name": "spaceId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "SpaceToUser_spaceId_Space_id_fk": {
+          "name": "SpaceToUser_spaceId_Space_id_fk",
+          "tableFrom": "SpaceToUser",
+          "tableTo": "Space",
+          "columnsFrom": [
+            "spaceId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "SpaceToUser_userId_User_id_fk": {
+          "name": "SpaceToUser_userId_User_id_fk",
+          "tableFrom": "SpaceToUser",
+          "tableTo": "User",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "SpaceToUser_spaceId_userId_pk": {
+          "name": "SpaceToUser_spaceId_userId_pk",
+          "columns": [
+            "spaceId",
+            "userId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Stream": {
+      "name": "Stream",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chatId": {
+          "name": "chatId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Stream_chatId_Chat_id_fk": {
+          "name": "Stream_chatId_Chat_id_fk",
+          "tableFrom": "Stream",
+          "tableTo": "Chat",
+          "columnsFrom": [
+            "chatId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "Stream_id_pk": {
+          "name": "Stream_id_pk",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Suggestion": {
+      "name": "Suggestion",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "documentId": {
+          "name": "documentId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "documentCreatedAt": {
+          "name": "documentCreatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "originalText": {
+          "name": "originalText",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggestedText": {
+          "name": "suggestedText",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isResolved": {
+          "name": "isResolved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Suggestion_userId_User_id_fk": {
+          "name": "Suggestion_userId_User_id_fk",
+          "tableFrom": "Suggestion",
+          "tableTo": "User",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "Suggestion_documentId_documentCreatedAt_Document_id_createdAt_fk": {
+          "name": "Suggestion_documentId_documentCreatedAt_Document_id_createdAt_fk",
+          "tableFrom": "Suggestion",
+          "tableTo": "Document",
+          "columnsFrom": [
+            "documentId",
+            "documentCreatedAt"
+          ],
+          "columnsTo": [
+            "id",
+            "createdAt"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "Suggestion_id_pk": {
+          "name": "Suggestion_id_pk",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.TokenUsage": {
+      "name": "TokenUsage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_usage_data": {
+          "name": "raw_usage_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_metadata": {
+          "name": "provider_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.User": {
+      "name": "User",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password": {
+          "name": "password",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selectedSpaceId": {
+          "name": "selectedSpaceId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emailVerificationToken": {
+          "name": "emailVerificationToken",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hasCompletedOnboarding": {
+          "name": "hasCompletedOnboarding",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "profileNotes": {
+          "name": "profileNotes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "User_selectedSpaceId_Space_id_fk": {
+          "name": "User_selectedSpaceId_Space_id_fk",
+          "tableFrom": "User",
+          "tableTo": "Space",
+          "columnsFrom": [
+            "selectedSpaceId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Vote_v2": {
+      "name": "Vote_v2",
+      "schema": "",
+      "columns": {
+        "chatId": {
+          "name": "chatId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "messageId": {
+          "name": "messageId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isUpvoted": {
+          "name": "isUpvoted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Vote_v2_chatId_Chat_id_fk": {
+          "name": "Vote_v2_chatId_Chat_id_fk",
+          "tableFrom": "Vote_v2",
+          "tableTo": "Chat",
+          "columnsFrom": [
+            "chatId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "Vote_v2_messageId_Message_v2_id_fk": {
+          "name": "Vote_v2_messageId_Message_v2_id_fk",
+          "tableFrom": "Vote_v2",
+          "tableTo": "Message_v2",
+          "columnsFrom": [
+            "messageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "Vote_v2_chatId_messageId_pk": {
+          "name": "Vote_v2_chatId_messageId_pk",
+          "columns": [
+            "chatId",
+            "messageId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Vote": {
+      "name": "Vote",
+      "schema": "",
+      "columns": {
+        "chatId": {
+          "name": "chatId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "messageId": {
+          "name": "messageId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isUpvoted": {
+          "name": "isUpvoted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Vote_chatId_Chat_id_fk": {
+          "name": "Vote_chatId_Chat_id_fk",
+          "tableFrom": "Vote",
+          "tableTo": "Chat",
+          "columnsFrom": [
+            "chatId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "Vote_messageId_Message_id_fk": {
+          "name": "Vote_messageId_Message_id_fk",
+          "tableFrom": "Vote",
+          "tableTo": "Message",
+          "columnsFrom": [
+            "messageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "Vote_chatId_messageId_pk": {
+          "name": "Vote_chatId_messageId_pk",
+          "columns": [
+            "chatId",
+            "messageId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/conversational-ui/lib/db/migrations/meta/_journal.json
+++ b/conversational-ui/lib/db/migrations/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1750351007882,
       "tag": "0013_gifted_silver_centurion",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1752765137129,
+      "tag": "0014_material_iron_patriot",
+      "breakpoints": true
     }
   ]
 }

--- a/conversational-ui/lib/db/queries.ts
+++ b/conversational-ui/lib/db/queries.ts
@@ -18,6 +18,8 @@ import {
   space,
   spaceToUser,
   stream,
+  tokenUsage,
+  type TokenUsage,
 } from './schema';
 import { ArtifactKind } from '@/components/artifact';
 
@@ -793,6 +795,77 @@ export async function updateUserProfile(userId: string, updates: { name?: string
     return await db.update(user).set(updates).where(eq(user.id, userId));
   } catch (error) {
     console.error('Failed to update user profile');
+    throw error;
+  }
+}
+
+// Token usage queries
+export async function getTokenUsageByUser(userId: string): Promise<Array<TokenUsage & { chatId: string }>> {
+  try {
+    return await db
+      .select({
+        id: tokenUsage.id,
+        messageId: tokenUsage.messageId,
+        provider: tokenUsage.provider,
+        model: tokenUsage.model,
+        rawUsageData: tokenUsage.rawUsageData,
+        providerMetadata: tokenUsage.providerMetadata,
+        createdAt: tokenUsage.createdAt,
+        chatId: chat.id,
+      })
+      .from(tokenUsage)
+      .innerJoin(message, eq(tokenUsage.messageId, message.id))
+      .innerJoin(chat, eq(message.chatId, chat.id))
+      .where(eq(chat.userId, userId))
+      .orderBy(desc(tokenUsage.createdAt));
+  } catch (error) {
+    console.error('Failed to get token usage by user');
+    throw error;
+  }
+}
+
+export async function getTokenUsageBySpace(spaceId: string): Promise<Array<TokenUsage & { chatId: string }>> {
+  try {
+    return await db
+      .select({
+        id: tokenUsage.id,
+        messageId: tokenUsage.messageId,
+        provider: tokenUsage.provider,
+        model: tokenUsage.model,
+        rawUsageData: tokenUsage.rawUsageData,
+        providerMetadata: tokenUsage.providerMetadata,
+        createdAt: tokenUsage.createdAt,
+        chatId: chat.id,
+      })
+      .from(tokenUsage)
+      .innerJoin(message, eq(tokenUsage.messageId, message.id))
+      .innerJoin(chat, eq(message.chatId, chat.id))
+      .where(eq(chat.spaceId, spaceId))
+      .orderBy(desc(tokenUsage.createdAt));
+  } catch (error) {
+    console.error('Failed to get token usage by space');
+    throw error;
+  }
+}
+
+export async function getTokenUsageByChat(chatId: string): Promise<Array<TokenUsage>> {
+  try {
+    return await db
+      .select({
+        id: tokenUsage.id,
+        messageId: tokenUsage.messageId,
+        provider: tokenUsage.provider,
+        model: tokenUsage.model,
+        rawUsageData: tokenUsage.rawUsageData,
+        providerMetadata: tokenUsage.providerMetadata,
+        createdAt: tokenUsage.createdAt,
+      })
+      .from(tokenUsage)
+      .innerJoin(message, eq(tokenUsage.messageId, message.id))
+      .where(eq(message.chatId, chatId))
+      .orderBy(desc(tokenUsage.createdAt));
+  } catch (error) {
+    console.error('Failed to get token usage by chat');
     throw error;
   }
 }

--- a/conversational-ui/lib/db/schema.ts
+++ b/conversational-ui/lib/db/schema.ts
@@ -9,6 +9,7 @@ import {
   primaryKey,
   foreignKey,
   boolean,
+  jsonb,
 } from 'drizzle-orm/pg-core';
 
 export const space = pgTable('Space', {
@@ -205,3 +206,16 @@ export const stream = pgTable(
 );
 
 export type Stream = InferSelectModel<typeof stream>;
+
+export const tokenUsage = pgTable('TokenUsage', {
+  id: uuid('id').primaryKey().notNull().defaultRandom(),
+  messageId: uuid('message_id')
+    .notNull(),
+  provider: varchar('provider', { length: 50 }).notNull(),
+  model: varchar('model', { length: 100 }).notNull(),
+  rawUsageData: jsonb('raw_usage_data').notNull(),
+  providerMetadata: jsonb('provider_metadata'),
+  createdAt: timestamp('created_at').notNull().defaultNow(),
+});
+
+export type TokenUsage = InferSelectModel<typeof tokenUsage>;

--- a/conversational-ui/lib/token-usage.ts
+++ b/conversational-ui/lib/token-usage.ts
@@ -1,0 +1,41 @@
+import 'server-only';
+
+import { db } from '@/lib/db';
+import { tokenUsage } from '@/lib/db/schema';
+import { myProvider } from "@/lib/ai/models";
+
+export interface TokenUsageData {
+  messageId: string;
+  provider: string;
+  model: string;
+  rawUsageData: any;
+  providerMetadata?: any;
+}
+
+export async function recordTokenUsage(data: TokenUsageData) {
+  try {
+    return await db.insert(tokenUsage).values({
+      messageId: data.messageId,
+      provider: data.provider,
+      model: data.model,
+      rawUsageData: data.rawUsageData,
+      providerMetadata: data.providerMetadata,
+      createdAt: new Date(),
+    });
+  } catch (error) {
+    console.error('Failed to record token usage:', error);
+    // Don't throw - token usage tracking shouldn't break the chat flow
+  }
+}
+
+export function extractModel(selectedChatModel: string) {
+  const languageModel = myProvider.languageModel(selectedChatModel);
+  if (!languageModel) {
+      // Don't throw - token usage tracking shouldn't break the chat flow
+      console.error(`Language model not found for: ${selectedChatModel}`);
+  }
+  return {
+    chatModelProvider: languageModel.provider,
+    chatModelName: languageModel.modelId,
+  }
+}


### PR DESCRIPTION
## Problem

Currently, we have no visibility into LLM token consumption for chat interactions in the Conversational UI. Users and administrators cannot track:
- How many tokens are consumed per message
- Token usage patterns by user/space/message
- Raw usage data for cost analysis and optimization

## Solution

Implement **minimal token usage tracking** with raw usage data and provider metadata per message ID, model, and provider. Keep it as simple as possible.

### Key Design Decisions

1. **Raw usage data only** – Store the complete usage object from AI SDK without interpretation
2. **Per-message tracking** – Usage is linked to each message via foreign key
3. **Minimal schema** – Only essential fields, derive user/space/chat through joins
4. **Provider metadata included** – Keep debugging and context information
5. **Simple implementation** – Direct usage capture in onFinish callback

### Implementation Plan

#### 1. **Add `token_usage` table (minimal schema with metadata)**
```sql
CREATE TABLE token_usage (
  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
  message_id UUID NOT NULL REFERENCES "Message_v2"(id),
  provider VARCHAR(50) NOT NULL,
  model VARCHAR(100) NOT NULL,
  raw_usage_data JSONB NOT NULL,
  provider_metadata JSONB,
  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
);
```

#### 2. **Capture usage in chat API endpoint**
```typescript
const result = streamText({
  model: myProvider.languageModel(selectedChatModel),
  messages,
  // ... other options
  onFinish: async ({ usage, response, experimental_providerMetadata }) => {
    if (usage && assistantMessage?.id) {
      await recordTokenUsage({
        messageId: assistantMessage.id,
        provider: extractProvider(selectedChatModel),
        model: selectedChatModel,
        rawUsageData: usage,
        providerMetadata: experimental_providerMetadata,
      });
    }
  }
});
```

#### 3. **Create simple token usage recording utility**
```typescript
export async function recordTokenUsage(data: {
  messageId: string;
  provider: string;
  model: string;
  rawUsageData: any;
  providerMetadata?: any;
}) {
  return db.insert(tokenUsage).values({
    messageId: data.messageId,
    provider: data.provider,
    model: data.model,
    rawUsageData: data.rawUsageData,
    providerMetadata: data.providerMetadata,
    createdAt: new Date(),
  });
}
```

#### 4. **Query examples (with joins for analytics)**
```typescript
// Get usage by user
const userUsage = await db
  .select()
  .from(tokenUsage)
  .innerJoin(message, eq(tokenUsage.messageId, message.id))
  .innerJoin(chat, eq(message.chatId, chat.id))
  .where(eq(chat.userId, userId));

// Get usage by space
const spaceUsage = await db
  .select()
  .from(tokenUsage)
  .innerJoin(message, eq(tokenUsage.messageId, message.id))
  .innerJoin(chat, eq(message.chatId, chat.id))
  .where(eq(chat.spaceId, spaceId));
```

### Acceptance Criteria

- [ ] `token_usage` table created with minimal schema including provider metadata
- [ ] All chat interactions record token usage per assistant message
- [ ] Raw usage data and provider metadata stored as JSONB
- [ ] Database migration runs successfully
- [ ] Type safety: Proper TypeScript types for schema
- [ ] Test: Each assistant message generates a token usage record
- [ ] Analytics queries work through joins

### Files to Modify

- `conversational-ui/lib/db/schema.ts` - Add token_usage table
- `conversational-ui/app/(chat)/api/chat/route.ts` - Add usage recording in onFinish
- `conversational-ui/lib/utils/token-usage.ts` - New usage recording utility
- `conversational-ui/lib/db/migrations/` - New migration file

### Benefits

1. **Maximum simplicity**: Only essential fields, minimal code
2. **Normalized design**: Clean relationships, no data duplication
3. **Future-proof**: Raw JSONB data works with any provider's usage format
4. **Debugging ready**: Provider metadata for troubleshooting and context
5. **Analytics-ready**: Join queries provide full analytical capabilities
6. **Maintainable**: Minimal fields, simple logic

### Priority: High
This provides essential token usage visibility with minimal implementation complexity while preserving useful debugging information.

### Additional Requirements
- Ensure `pnpm build:only` passes before submitting the PR
- Follow existing code patterns and conventions in the codebase
- Include proper error handling for token usage recording
- Make sure the implementation is backward compatible