### PR TITLE
Fix Mermaid diagram dark mode visibility issues

### DIFF
--- a/conversational-ui/app/globals.css
+++ b/conversational-ui/app/globals.css
@@ -640,3 +640,163 @@ ol li::before {
   width: 2em;
   text-align: right;
 }
+
+/* Mermaid diagram styling overrides for improved visibility */
+/* Light mode Mermaid overrides */
+:not(.dark) .mermaid svg {
+  background-color: transparent !important;
+}
+
+:not(.dark) .mermaid .node rect,
+:not(.dark) .mermaid .node circle,
+:not(.dark) .mermaid .node ellipse,
+:not(.dark) .mermaid .node polygon {
+  stroke: #374151 !important;
+  stroke-width: 2px !important;
+}
+
+:not(.dark) .mermaid .edgePath path {
+  stroke: #4b5563 !important;
+  stroke-width: 2px !important;
+}
+
+:not(.dark) .mermaid .arrowheadPath {
+  fill: #4b5563 !important;
+  stroke: #4b5563 !important;
+}
+
+:not(.dark) .mermaid .edgeLabel {
+  background-color: rgba(255, 255, 255, 0.9) !important;
+  color: #1f2937 !important;
+  border: 1px solid #d1d5db !important;
+  border-radius: 4px !important;
+  padding: 2px 6px !important;
+}
+
+:not(.dark) .mermaid .nodeLabel,
+:not(.dark) .mermaid .edgeLabel text {
+  fill: #1f2937 !important;
+  color: #1f2937 !important;
+  font-weight: 500 !important;
+}
+
+/* Dark mode Mermaid overrides */
+.dark .mermaid svg {
+  background-color: transparent !important;
+}
+
+.dark .mermaid .node rect,
+.dark .mermaid .node circle,
+.dark .mermaid .node ellipse,
+.dark .mermaid .node polygon {
+  stroke: #d1d5db !important;
+  stroke-width: 2px !important;
+  fill: #374151 !important;
+}
+
+.dark .mermaid .edgePath path {
+  stroke: #9ca3af !important;
+  stroke-width: 2px !important;
+}
+
+.dark .mermaid .arrowheadPath {
+  fill: #9ca3af !important;
+  stroke: #9ca3af !important;
+}
+
+.dark .mermaid .edgeLabel {
+  background-color: rgba(31, 41, 55, 0.9) !important;
+  color: #f9fafb !important;
+  border: 1px solid #6b7280 !important;
+  border-radius: 4px !important;
+  padding: 2px 6px !important;
+}
+
+.dark .mermaid .nodeLabel,
+.dark .mermaid .edgeLabel text {
+  fill: #f9fafb !important;
+  color: #f9fafb !important;
+  font-weight: 500 !important;
+}
+
+/* Additional overrides for specific diagram types */
+/* Flowchart specific overrides - Light mode */
+:not(.dark) .mermaid .flowchart-link {
+  stroke: #4b5563 !important;
+  stroke-width: 2px !important;
+}
+
+:not(.dark) .mermaid .marker {
+  fill: #4b5563 !important;
+  stroke: #4b5563 !important;
+}
+
+/* Flowchart specific overrides - Dark mode */
+.dark .mermaid .flowchart-link {
+  stroke: #9ca3af !important;
+  stroke-width: 2px !important;
+}
+
+.dark .mermaid .marker {
+  fill: #9ca3af !important;
+  stroke: #9ca3af !important;
+}
+
+/* Sequence diagram overrides - Light mode */
+:not(.dark) .mermaid .actor {
+  stroke: #374151 !important;
+  stroke-width: 2px !important;
+}
+
+:not(.dark) .mermaid .messageLine0,
+:not(.dark) .mermaid .messageLine1 {
+  stroke: #4b5563 !important;
+  stroke-width: 2px !important;
+}
+
+/* Sequence diagram overrides - Dark mode */
+.dark .mermaid .actor {
+  stroke: #d1d5db !important;
+  stroke-width: 2px !important;
+  fill: #374151 !important;
+}
+
+.dark .mermaid .messageLine0,
+.dark .mermaid .messageLine1 {
+  stroke: #9ca3af !important;
+  stroke-width: 2px !important;
+}
+
+/* Class diagram overrides - Light mode */
+:not(.dark) .mermaid .relation {
+  stroke: #4b5563 !important;
+  stroke-width: 2px !important;
+}
+
+/* Class diagram overrides - Dark mode */
+.dark .mermaid .relation {
+  stroke: #9ca3af !important;
+  stroke-width: 2px !important;
+}
+
+/* State diagram overrides - Light mode */
+:not(.dark) .mermaid .stateGroup .state-title {
+  fill: #1f2937 !important;
+  font-weight: 500 !important;
+}
+
+:not(.dark) .mermaid .transition {
+  stroke: #4b5563 !important;
+  stroke-width: 2px !important;
+}
+
+/* State diagram overrides - Dark mode */
+.dark .mermaid .stateGroup .state-title {
+  fill: #f9fafb !important;
+  font-weight: 500 !important;
+}
+
+.dark .mermaid .transition {
+  stroke: #9ca3af !important;
+  stroke-width: 2px !important;
+}


### PR DESCRIPTION
The Mermaid diagrams have poor visibility in dark mode with barely visible arrows and labels. The current implementation uses a static 'default' theme and doesn't respond to theme changes. Need to implement:

1. Dynamic theme detection that responds to theme toggles
2. Proper Mermaid theme configuration for both light and dark modes
3. Re-rendering of diagrams when theme changes
4. Better contrast for arrows, labels, and text in dark mode
5. CSS overrides for Mermaid-generated SVG elements to ensure visibility

The main issues are:
- Arrows and labels are barely visible in dark mode
- Hardcoded colors don't adapt to theme changes
- No re-rendering when switching between light/dark modes
- Poor contrast between diagram elements and dark background

Files to modify:
- /conversational-ui/components/mermaid-diagram.tsx (main logic)
- /conversational-ui/app/globals.css (CSS overrides for Mermaid SVG elements)

The solution should:
- Use 'dark' theme for dark mode and 'default'/'base' for light mode
- Listen to theme changes and re-render diagrams
- Add CSS overrides to ensure proper visibility of all diagram elements
- Maintain backward compatibility with existing diagrams