### PR TITLE
Create settings_to_env_string function with pytest tests

### DIFF
--- a/issue-solver/src/issue_solver/utils/__init__.py
+++ b/issue-solver/src/issue_solver/utils/__init__.py
@@ -1,0 +1,5 @@
+# Utils package for issue_solver
+
+from .settings_converter import settings_to_env_string
+
+__all__ = ["settings_to_env_string"]

--- a/issue-solver/src/issue_solver/utils/settings_converter.py
+++ b/issue-solver/src/issue_solver/utils/settings_converter.py
@@ -1,0 +1,156 @@
+"""Utility functions for converting BaseSettings objects to .env file format."""
+
+from pathlib import Path
+from typing import Any, Dict
+from urllib.parse import urlparse
+
+from pydantic import AnyUrl
+from pydantic_settings import BaseSettings
+
+
+def settings_to_env_string(settings: BaseSettings) -> str:
+    """
+    Convert a BaseSettings object to .env file content string.
+    
+    Args:
+        settings: The BaseSettings object to convert
+        
+    Returns:
+        A string containing the equivalent .env file content
+        
+    Features:
+    - Handles nested BaseSettings objects using env_nested_delimiter (default '__')
+    - Handles env_prefix from model_config
+    - Formats values appropriately (strings with spaces in quotes, booleans as lowercase)
+    - Sorts keys for consistent output
+    - Skips None values
+    """
+    env_vars = _extract_env_variables(settings)
+    
+    if not env_vars:
+        return ""
+    
+    # Sort keys for consistent output
+    sorted_vars = sorted(env_vars.items())
+    
+    # Format each variable
+    lines = []
+    for key, value in sorted_vars:
+        formatted_value = _format_env_value(value)
+        lines.append(f"{key}={formatted_value}")
+    
+    return "\n".join(lines)
+
+
+def _extract_env_variables(settings: BaseSettings, parent_prefix: str = "") -> Dict[str, Any]:
+    """
+    Extract environment variables from a BaseSettings object.
+    
+    Args:
+        settings: The BaseSettings object to extract from
+        parent_prefix: Prefix to prepend to variable names (for nested objects)
+        
+    Returns:
+        Dictionary of environment variable names to their values
+    """
+    env_vars = {}
+    
+    # Get configuration from model_config
+    model_config = getattr(settings, 'model_config', None)
+    env_prefix = ""
+    env_nested_delimiter = "__"
+    
+    if model_config:
+        env_prefix = getattr(model_config, 'env_prefix', "")
+        env_nested_delimiter = getattr(model_config, 'env_nested_delimiter', "__")
+    
+    # Determine the current prefix for this level
+    current_prefix = ""
+    if parent_prefix:
+        # We're in a nested context, use parent prefix
+        current_prefix = parent_prefix
+    elif env_prefix:
+        # We're at root level with an env_prefix
+        current_prefix = env_prefix.rstrip('_')
+    
+    # Get all field values
+    for field_name, field_info in settings.model_fields.items():
+        value = getattr(settings, field_name)
+        
+        # Skip None values
+        if value is None:
+            continue
+            
+        field_name_upper = field_name.upper()
+        
+        # Handle nested BaseSettings objects
+        if isinstance(value, BaseSettings):
+            # Build nested prefix using delimiter
+            if current_prefix:
+                nested_prefix = f"{current_prefix}{env_nested_delimiter}{field_name_upper}"
+            else:
+                nested_prefix = field_name_upper
+            nested_vars = _extract_env_variables(value, nested_prefix)
+            env_vars.update(nested_vars)
+        else:
+            # Build the environment variable name for non-nested values
+            if current_prefix:
+                # Use the appropriate delimiter based on context
+                if parent_prefix:
+                    # We're in a nested object - use the nested delimiter but only once more
+                    env_var_name = f"{current_prefix}{env_nested_delimiter}{field_name_upper}"
+                else:
+                    # We're at root level with prefix - use underscore
+                    if current_prefix.endswith('_'):
+                        env_var_name = f"{current_prefix}{field_name_upper}"
+                    else:
+                        env_var_name = f"{current_prefix}_{field_name_upper}"
+            else:
+                env_var_name = field_name_upper
+            env_vars[env_var_name] = value
+    
+    return env_vars
+
+
+def _format_env_value(value: Any) -> str:
+    """
+    Format a value for use in a .env file.
+    
+    Args:
+        value: The value to format
+        
+    Returns:
+        Formatted string representation suitable for .env files
+    """
+    if value is None:
+        return ""
+    elif isinstance(value, bool):
+        return str(value).lower()
+    elif isinstance(value, (int, float)):
+        return str(value)
+    elif isinstance(value, Path):
+        path_str = str(value)
+        # Quote paths that contain spaces
+        if " " in path_str:
+            return f'"{path_str}"'
+        return path_str
+    elif isinstance(value, AnyUrl):
+        url_str = str(value)
+        # Quote URLs that contain spaces (unlikely but possible)
+        if " " in url_str:
+            return f'"{url_str}"'
+        return url_str
+    elif isinstance(value, str):
+        # Quote strings that contain spaces or quotes
+        if " " in value or '"' in value:
+            # Escape any existing quotes
+            escaped_value = value.replace('"', '\\"')
+            return f'"{escaped_value}"'
+        return value
+    else:
+        # For any other type, convert to string and apply string rules
+        str_value = str(value)
+        if " " in str_value or '"' in str_value:
+            escaped_value = str_value.replace('"', '\\"')
+            return f'"{escaped_value}"'
+        return str_value

--- a/issue-solver/tests/utils/__init__.py
+++ b/issue-solver/tests/utils/__init__.py
@@ -1,0 +1,1 @@
+# Utils tests package

--- a/issue-solver/tests/utils/test_settings_converter.py
+++ b/issue-solver/tests/utils/test_settings_converter.py
@@ -1,0 +1,524 @@
+"""Tests for settings_converter module."""
+
+from pathlib import Path
+from typing import Optional
+
+import pytest
+from pydantic import AnyUrl, Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+from issue_solver.utils.settings_converter import settings_to_env_string
+
+
+class SimpleSettings(BaseSettings):
+    """Simple flat settings for testing."""
+    name: str = "test"
+    count: int = 42
+    enabled: bool = True
+    path: Optional[Path] = None
+    url: Optional[AnyUrl] = None
+
+
+class NestedChildSettings(BaseSettings):
+    """Nested child settings."""
+    host: str = "localhost"
+    port: int = 5432
+    ssl: bool = False
+
+
+class NestedParentSettings(BaseSettings):
+    """Parent settings with nested child."""
+    model_config = SettingsConfigDict(
+        env_nested_delimiter="__",
+        env_file=".env",
+        env_file_encoding="utf-8",
+        extra="ignore",
+    )
+    
+    app_name: str = "myapp"
+    debug: bool = False
+    database: NestedChildSettings = Field(default_factory=NestedChildSettings)
+
+
+class PrefixedSettings(BaseSettings):
+    """Settings with env_prefix."""
+    model_config = SettingsConfigDict(
+        env_prefix="MYAPP_",
+        env_file=".env",
+        env_file_encoding="utf-8",
+        extra="ignore",
+    )
+    
+    api_key: str = "secret"
+    timeout: int = 30
+
+
+class PrefixedNestedSettings(BaseSettings):
+    """Parent with prefix and nested child with prefix."""
+    model_config = SettingsConfigDict(
+        env_prefix="PARENT_",
+        env_nested_delimiter="__",
+        env_file=".env",
+        env_file_encoding="utf-8",
+        extra="ignore",
+    )
+    
+    name: str = "parent"
+    child: PrefixedSettings = Field(default_factory=PrefixedSettings)
+
+
+class SpecialValuesSettings(BaseSettings):
+    """Settings with special values that need careful formatting."""
+    string_with_spaces: str = "hello world"
+    string_with_quotes: str = 'say "hello"'
+    path_with_spaces: Path = Path("/path with spaces/file.txt")
+    url_example: AnyUrl = AnyUrl("https://example.com/path?param=value")
+    none_value: Optional[str] = None
+    empty_string: str = ""
+    zero_value: int = 0
+    false_value: bool = False
+
+
+class SolveCommandLikeSettings(BaseSettings):
+    """Settings similar to SolveCommand for realistic testing."""
+    model_config = SettingsConfigDict(
+        env_nested_delimiter="__",
+        env_file=".env",
+        env_file_encoding="utf-8",
+        extra="ignore",
+    )
+    
+    issue: str = "Fix the bug"
+    agent: str = "swe-agent"
+    ai_model: str = "gpt-4o-mini"
+    ai_model_version: Optional[str] = None
+    repo_path: Path = Path(".")
+    process_id: Optional[str] = None
+    database_url: Optional[str] = None
+    redis_url: Optional[str] = None
+
+
+class GitLikeSettings(BaseSettings):
+    """Settings similar to GitSettings for nested testing."""
+    repository_url: str = "https://github.com/user/repo.git"
+    access_token: str = "ghp_token123"
+    user_mail: str = "agent@umans.ai"
+    user_name: str = "Umans Agent"
+
+
+class SolveCommandWithGitSettings(BaseSettings):
+    """Combined settings with nested Git settings."""
+    model_config = SettingsConfigDict(
+        env_nested_delimiter="__",
+        env_file=".env",
+        env_file_encoding="utf-8",
+        extra="ignore",
+    )
+    
+    issue: str = "Fix the bug"
+    agent: str = "swe-agent"
+    git: GitLikeSettings = Field(default_factory=GitLikeSettings)
+
+
+class PrepareCommandLikeSettings(BaseSettings):
+    """Settings similar to PrepareCommand."""
+    model_config = SettingsConfigDict(
+        env_nested_delimiter="__",
+        env_file=".env",
+        env_file_encoding="utf-8",
+        extra="ignore",
+    )
+    
+    process_id: str = "proc-123"
+    repo_path: Path = Path("/workspace/repo")
+    url: str = "https://github.com/user/repo.git"
+    access_token: str = "ghp_token456"
+    install_script: Path = Path("./install.sh")
+
+
+class TestSimpleFlatSettings:
+    """Test cases for simple flat settings."""
+    
+    def test_given_simple_settings_when_converting_then_returns_flat_env_vars(self):
+        # Given
+        settings = SimpleSettings(
+            name="myapp",
+            count=100,
+            enabled=True
+        )
+        
+        # When
+        result = settings_to_env_string(settings)
+        
+        # Then
+        expected_lines = [
+            "COUNT=100",
+            "ENABLED=true",
+            "NAME=myapp"
+        ]
+        assert result == "\n".join(expected_lines)
+    
+    def test_given_settings_with_none_values_when_converting_then_skips_none_values(self):
+        # Given
+        settings = SimpleSettings(
+            name="test",
+            count=42,
+            enabled=False,
+            path=None,
+            url=None
+        )
+        
+        # When
+        result = settings_to_env_string(settings)
+        
+        # Then
+        expected_lines = [
+            "COUNT=42",
+            "ENABLED=false",
+            "NAME=test"
+        ]
+        assert result == "\n".join(expected_lines)
+    
+    def test_given_settings_with_path_and_url_when_converting_then_formats_correctly(self):
+        # Given
+        settings = SimpleSettings(
+            name="test",
+            count=1,
+            enabled=True,
+            path=Path("/home/user/file.txt"),
+            url=AnyUrl("https://api.example.com/v1")
+        )
+        
+        # When
+        result = settings_to_env_string(settings)
+        
+        # Then
+        expected_lines = [
+            "COUNT=1",
+            "ENABLED=true",
+            "NAME=test",
+            "PATH=/home/user/file.txt",
+            "URL=https://api.example.com/v1"
+        ]
+        assert result == "\n".join(expected_lines)
+
+
+class TestNestedSettings:
+    """Test cases for nested settings."""
+    
+    def test_given_nested_settings_when_converting_then_uses_delimiter(self):
+        # Given
+        child = NestedChildSettings(host="db.example.com", port=3306, ssl=True)
+        settings = NestedParentSettings(
+            app_name="webapp",
+            debug=True,
+            database=child
+        )
+        
+        # When
+        result = settings_to_env_string(settings)
+        
+        # Then
+        expected_lines = [
+            "APP_NAME=webapp",
+            "DATABASE__HOST=db.example.com",
+            "DATABASE__PORT=3306",
+            "DATABASE__SSL=true",
+            "DEBUG=true"
+        ]
+        assert result == "\n".join(expected_lines)
+    
+    def test_given_empty_nested_settings_when_converting_then_handles_gracefully(self):
+        # Given
+        settings = NestedParentSettings()
+        
+        # When
+        result = settings_to_env_string(settings)
+        
+        # Then
+        expected_lines = [
+            "APP_NAME=myapp",
+            "DATABASE__HOST=localhost",
+            "DATABASE__PORT=5432",
+            "DATABASE__SSL=false",
+            "DEBUG=false"
+        ]
+        assert result == "\n".join(expected_lines)
+
+
+class TestPrefixedSettings:
+    """Test cases for settings with env_prefix."""
+    
+    def test_given_prefixed_settings_when_converting_then_adds_prefix(self):
+        # Given
+        settings = PrefixedSettings(
+            api_key="sk-123456",
+            timeout=60
+        )
+        
+        # When
+        result = settings_to_env_string(settings)
+        
+        # Then
+        expected_lines = [
+            "MYAPP_API_KEY=sk-123456",
+            "MYAPP_TIMEOUT=60"
+        ]
+        assert result == "\n".join(expected_lines)
+    
+    def test_given_prefixed_nested_settings_when_converting_then_combines_prefixes(self):
+        # Given
+        child = PrefixedSettings(api_key="nested-key", timeout=45)
+        settings = PrefixedNestedSettings(
+            name="parent-app",
+            child=child
+        )
+        
+        # When
+        result = settings_to_env_string(settings)
+        
+        # Then
+        expected_lines = [
+            "PARENT_CHILD__MYAPP_API_KEY=nested-key",
+            "PARENT_CHILD__MYAPP_TIMEOUT=45",
+            "PARENT_NAME=parent-app"
+        ]
+        assert result == "\n".join(expected_lines)
+
+
+class TestSpecialValueFormatting:
+    """Test cases for special value formatting."""
+    
+    def test_given_strings_with_spaces_when_converting_then_quotes_them(self):
+        # Given
+        settings = SpecialValuesSettings(
+            string_with_spaces="hello world test",
+            string_with_quotes="normal",
+            path_with_spaces=Path("/normal/path"),
+            url_example=AnyUrl("https://example.com"),
+            empty_string="",
+            zero_value=5,
+            false_value=True
+        )
+        
+        # When
+        result = settings_to_env_string(settings)
+        
+        # Then
+        expected_lines = [
+            "EMPTY_STRING=",
+            "FALSE_VALUE=true",
+            "PATH_WITH_SPACES=/normal/path",
+            "STRING_WITH_QUOTES=normal",
+            "STRING_WITH_SPACES=\"hello world test\"",
+            "URL_EXAMPLE=https://example.com",
+            "ZERO_VALUE=5"
+        ]
+        assert result == "\n".join(expected_lines)
+    
+    def test_given_strings_with_quotes_when_converting_then_escapes_quotes(self):
+        # Given
+        settings = SpecialValuesSettings(
+            string_with_quotes='He said "Hello World"',
+            string_with_spaces="normal",
+            path_with_spaces=Path("/path with spaces/file.txt"),
+            url_example=AnyUrl("https://example.com"),
+            empty_string="value",
+            zero_value=1,
+            false_value=False
+        )
+        
+        # When
+        result = settings_to_env_string(settings)
+        
+        # Then
+        expected_lines = [
+            "EMPTY_STRING=value",
+            "FALSE_VALUE=false",
+            "PATH_WITH_SPACES=\"/path with spaces/file.txt\"",
+            "STRING_WITH_QUOTES=\"He said \\\"Hello World\\\"\"",
+            "STRING_WITH_SPACES=normal",
+            "URL_EXAMPLE=https://example.com",
+            "ZERO_VALUE=1"
+        ]
+        assert result == "\n".join(expected_lines)
+    
+    def test_given_boolean_values_when_converting_then_formats_as_lowercase(self):
+        # Given
+        settings = SpecialValuesSettings(
+            false_value=True,
+            string_with_spaces="test",
+            string_with_quotes="test",
+            path_with_spaces=Path("/test"),
+            url_example=AnyUrl("https://example.com"),
+            empty_string="test",
+            zero_value=1
+        )
+        
+        # When
+        result = settings_to_env_string(settings)
+        
+        # Then
+        assert "FALSE_VALUE=true" in result
+        
+        # Test with False
+        settings.false_value = False
+        result = settings_to_env_string(settings)
+        assert "FALSE_VALUE=false" in result
+
+
+class TestRealisticScenarios:
+    """Test cases based on actual SolveCommand and PrepareCommand settings."""
+    
+    def test_given_solve_command_like_settings_when_converting_then_matches_expected_format(self):
+        # Given
+        settings = SolveCommandLikeSettings(
+            issue="Implement user authentication",
+            agent="claude-code",
+            ai_model="claude-3-sonnet",
+            ai_model_version="20241022",
+            repo_path=Path("/workspace/myapp"),
+            process_id="proc-uuid-123",
+            database_url="postgresql://user:pass@localhost/db",
+            redis_url="redis://localhost:6379/0"
+        )
+        
+        # When
+        result = settings_to_env_string(settings)
+        
+        # Then
+        expected_lines = [
+            "AGENT=claude-code",
+            "AI_MODEL=claude-3-sonnet",
+            "AI_MODEL_VERSION=20241022",
+            "DATABASE_URL=postgresql://user:pass@localhost/db",
+            "ISSUE=\"Implement user authentication\"",
+            "PROCESS_ID=proc-uuid-123",
+            "REDIS_URL=redis://localhost:6379/0",
+            "REPO_PATH=/workspace/myapp"
+        ]
+        assert result == "\n".join(expected_lines)
+    
+    def test_given_solve_command_with_git_settings_when_converting_then_handles_nested_correctly(self):
+        # Given
+        git_settings = GitLikeSettings(
+            repository_url="https://github.com/umans-ai/issue-solver.git",
+            access_token="ghp_secrettoken123",
+            user_mail="bot@umans.ai",
+            user_name="Umans Bot"
+        )
+        settings = SolveCommandWithGitSettings(
+            issue="Fix critical bug",
+            agent="swe-agent",
+            git=git_settings
+        )
+        
+        # When
+        result = settings_to_env_string(settings)
+        
+        # Then
+        expected_lines = [
+            "AGENT=swe-agent",
+            "GIT__ACCESS_TOKEN=ghp_secrettoken123",
+            "GIT__REPOSITORY_URL=https://github.com/umans-ai/issue-solver.git",
+            "GIT__USER_MAIL=bot@umans.ai",
+            "GIT__USER_NAME=\"Umans Bot\"",
+            "ISSUE=\"Fix critical bug\""
+        ]
+        assert result == "\n".join(expected_lines)
+    
+    def test_given_prepare_command_like_settings_when_converting_then_formats_correctly(self):
+        # Given
+        settings = PrepareCommandLikeSettings(
+            process_id="prepare-proc-456",
+            repo_path=Path("/tmp/workspace/my project"),
+            url="https://github.com/user/my-repo.git",
+            access_token="pat_github_token",
+            install_script=Path("./scripts/install dependencies.sh")
+        )
+        
+        # When
+        result = settings_to_env_string(settings)
+        
+        # Then
+        expected_lines = [
+            "ACCESS_TOKEN=pat_github_token",
+            "INSTALL_SCRIPT=\"./scripts/install dependencies.sh\"",
+            "PROCESS_ID=prepare-proc-456",
+            "REPO_PATH=\"/tmp/workspace/my project\"",
+            "URL=https://github.com/user/my-repo.git"
+        ]
+        assert result == "\n".join(expected_lines)
+
+
+class TestEdgeCases:
+    """Test cases for edge cases and error conditions."""
+    
+    def test_given_empty_settings_when_converting_then_returns_empty_string(self):
+        # Given
+        class EmptySettings(BaseSettings):
+            pass
+        
+        settings = EmptySettings()
+        
+        # When
+        result = settings_to_env_string(settings)
+        
+        # Then
+        assert result == ""
+    
+    def test_given_settings_with_all_none_values_when_converting_then_returns_empty_string(self):
+        # Given
+        class AllNoneSettings(BaseSettings):
+            value1: Optional[str] = None
+            value2: Optional[int] = None
+            value3: Optional[bool] = None
+        
+        settings = AllNoneSettings()
+        
+        # When
+        result = settings_to_env_string(settings)
+        
+        # Then
+        assert result == ""
+    
+    def test_given_complex_string_with_special_characters_when_converting_then_escapes_correctly(self):
+        # Given
+        class SpecialStringSettings(BaseSettings):
+            complex_string: str = 'Value with "quotes" and spaces and\nnewlines'
+        
+        settings = SpecialStringSettings()
+        
+        # When
+        result = settings_to_env_string(settings)
+        
+        # Then
+        expected = 'COMPLEX_STRING="Value with \\"quotes\\" and spaces and\nnewlines"'
+        assert result == expected
+    
+    def test_given_settings_with_custom_delimiter_when_converting_then_uses_custom_delimiter(self):
+        # Given
+        class CustomDelimiterSettings(BaseSettings):
+            model_config = SettingsConfigDict(
+                env_nested_delimiter="___",
+                env_file=".env",
+                env_file_encoding="utf-8",
+                extra="ignore",
+            )
+            
+            parent_value: str = "parent"
+            child: NestedChildSettings = Field(default_factory=NestedChildSettings)
+        
+        settings = CustomDelimiterSettings()
+        
+        # When
+        result = settings_to_env_string(settings)
+        
+        # Then
+        expected_lines = [
+            "CHILD___HOST=localhost",
+            "CHILD___PORT=5432",
+            "CHILD___SSL=false",
+            "PARENT_VALUE=parent"
+        ]
+        assert result == "\n".join(expected_lines)


### PR DESCRIPTION
Create a function `settings_to_env_string` that takes a BaseSettings object and returns a string containing the equivalent .env file content. The function should:

1. Handle nested BaseSettings objects using the env_nested_delimiter (default '__')
2. Handle env_prefix from model_config
3. Format values appropriately (strings with spaces in quotes, booleans as lowercase, etc.)
4. Sort keys for consistent output
5. Skip None values

Create comprehensive pytest tests using Given-When-Then structure with examples based on SolveCommand and PrepareCommand settings from the codebase. Tests should cover:
- Simple flat settings
- Nested settings with delimiter
- Settings with env_prefix
- Various data types (str, int, bool, Path, AnyUrl, None)
- Edge cases like strings with quotes and spaces

Place the function in `src/issue_solver/utils/settings_converter.py` and tests in `tests/utils/test_settings_converter.py`.