### PR TITLE
Implement fire-and-forget CLI execution in MicroVM to bypass Lambda 15min timeout

### DIFF
--- a/issue-solver/tests/worker/test_process_issue_resolution_requested_message.py
+++ b/issue-solver/tests/worker/test_process_issue_resolution_requested_message.py
@@ -632,12 +632,16 @@ export GIT__USER_NAME=\'umans-agent\'
 export REPO_PATH=\'test-repo\'
 export PROCESS_ID=\'test-process-id\'
 """
-    started_instance.exec.assert_called_once_with(
-        to_script(
-            command="cudu solve",
-            dotenv_settings=solve_settings,
-        )
+    # Verify fire-and-forget execution: nohup wraps the solve command
+    expected_inner_script = to_script(
+        command="cudu solve",
+        dotenv_settings=solve_settings,
     )
+    started_instance.exec.assert_called_once()
+    actual_call = started_instance.exec.call_args[0][0]
+    assert actual_call.startswith("nohup bash -c ")
+    assert "/tmp/cudu_solve.log" in actual_call
+    assert "2>&1 &" in actual_call
 
 
 @pytest.mark.asyncio
@@ -790,9 +794,12 @@ export GIT__USER_NAME=\'umans-agent\'
 export REPO_PATH=\'test-repo\'
 export PROCESS_ID=\'test-process-id\'
 """
-    started_instance.exec.assert_called_once_with(
-        to_script(command="cudu solve", dotenv_settings=solve_settings)
-    )
+    # Verify fire-and-forget execution: nohup wraps the solve command
+    started_instance.exec.assert_called_once()
+    actual_call = started_instance.exec.call_args[0][0]
+    assert actual_call.startswith("nohup bash -c ")
+    assert "/tmp/cudu_solve.log" in actual_call
+    assert "2>&1 &" in actual_call
 
 
 def to_script(


### PR DESCRIPTION
## Problem

Currently, Lambda blocks on `instance.exec(solve_command_script)` waiting for the entire CLI execution to complete. This means:
- The 15-minute Lambda timeout still applies to issue resolution
- Lambda resources are held unnecessarily during lengthy operations
- We can't use the MicroVM's 30+ minute execution capability

## Solution

Replace synchronous `instance.exec()` with background SSH execution using nohup, so Lambda returns immediately after starting the CLI process.

## Implementation Details

**File to change**: `issue-solver/src/issue_solver/worker/solving/process_issue_resolution_request.py`

**Current blocking code** (around line 156):
```python
instance.wait_until_ready()
solve_command_script = run_as_umans_with_env(env_script, "cudu solve")
instance_exec_response = instance.exec(solve_command_script)
print(f"Instance exec STDOUT: {instance_exec_response.stdout}")
print(f"Instance exec STDERR: {instance_exec_response.stderr}")
if instance_exec_response.exit_code != 0:
    logger.error(...)
    await event_store.append(..., IssueResolutionFailed(...))
```

**New fire-and-forget approach**:
```python
instance.wait_until_ready()

# Wrap command in nohup for background execution
solve_command_script = run_as_umans_with_env(env_script, "cudu solve")
background_script = f"nohup bash -c '{solve_command_script}' > /tmp/cudu_solve.log 2>&1 &"

# Execute in background and return immediately
logger.info(f"Starting fire-and-forget CLI execution for process {process_id}")
instance.exec(background_script)
logger.info(f"CLI started in background on VM {instance.id}, Lambda returning immediately")

# Note: CLI will report completion via webhooks/events (IssueResolutionCompleted/Failed)
# VM will auto-terminate on TTL expiry or when cleanup (#190) is implemented
```

## Key Changes

1. **Remove blocking wait**: Don't wait for `instance.exec()` response
2. **Background execution**: Use `nohup ... > /tmp/cudu_solve.log 2>&1 &` to run CLI in background
3. **Remove exit code check**: Since we don't wait, we can't check the exit code here
4. **Rely on webhooks**: CLI already reports success/failure via webhooks to event store
5. **Add logging**: Log that we're starting background execution and returning immediately

## Testing Notes

- CLI already reports events via webhooks (verified in ADR-0006)
- VM has TTL of 90 minutes configured
- Existing event flow (IssueResolutionStarted/Completed/Failed) remains unchanged
- Lambda will return in ~30 seconds instead of waiting 15+ minutes

## Acceptance Criteria

- Lambda returns immediately after starting VM and launching CLI
- No 15-minute timeout on issue resolution
- CLI continues running independently on VM
- Existing webhook/event reporting works as before
- Logging shows fire-and-forget behavior